### PR TITLE
Add convergence test for initial conditions

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,15 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# Set location of custom Boost install:
+set(Boost_INCLUDE_DIR /root/code/boost_1_78_0)
+#set(Boost_LIBRARY_DIR /root/code/boost_1_78_0/stage/lib)
+find_package(Boost COMPONENTS system filesystem REQUIRED)
+FIND_PACKAGE( Boost 1.78.0 COMPONENTS REQUIRED )
+INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
+
+message(STATUS "foo include dir: ${Boost_INCLUDE_DIR}")
+
 enable_testing()
 
 add_executable(
@@ -28,11 +37,13 @@ add_executable(
   ../src/plasma.cpp
   ../src/fft.cpp
 )
+
 target_link_libraries(
   mesh_test
   gtest_main
   lapack
   fftw3
+  ${Boost_LIBRARIES}
 )
 
 include(GoogleTest)

--- a/test/mms_test.cc
+++ b/test/mms_test.cc
@@ -2,57 +2,51 @@
 #include "../src/mesh.hpp"
 #include "../src/plasma.hpp"
 #include <cmath>
+#include <boost/math/statistics/linear_regression.hpp>
 
-TEST(MMSTest, InitialConditions) {
+TEST(MMSTest, SpatialInitialConditions) {
   Mesh mesh;
   Plasma plasma;
 
-  std::vector<double> nparticles;
-  std::vector<double> summed_error;
+  std::vector<double> log_nparticles;
+  std::vector<double> log_summed_error;
   double error;
 
-  // Deposit partilces onto mesh, and test that the resulting
+  // Deposit particles onto mesh, and test that the resulting
   // distribution tends to a cosine.
   int np = 1;
-  for(int j = 0; j < 20; j++){
+
+  // j < 20, 3.6 secs
+  // j < 11, 0.01 secs
+  for(int j = 0; j < 11; j++){
   	np *= 2;
 	Plasma plasma(np);
 
 	mesh.deposit(&plasma);
-	for(int i = 0; i < mesh.nmesh; i++){
-	  std::cout << mesh.charge_density[i] << " ";
-	}
-	std::cout << "\n";
+//	for(int i = 0; i < mesh.nmesh; i++){
+//	  std::cout << mesh.charge_density[i] << " ";
+//	}
+//	std::cout << "\n";
 
 	error = 0.0;
 	for(int i = 0; i < mesh.nmesh; i++){
 	  error += std::abs(mesh.charge_density[i] - (1.0 + 0.01 * cos( 2.0*M_PI*mesh.mesh[i]))/double(mesh.nintervals));
 	}
 
-	nparticles.push_back(np);
-	summed_error.push_back(error);
+	log_nparticles.push_back(std::log(np));
+	log_summed_error.push_back(std::log(error));
   }
+
+
+//  for(int j = 0; j < 20; j++){
+//	  std::cout << log_summed_error[j] << " ";
+//  }
+
+  using boost::math::statistics::simple_ordinary_least_squares;
+  auto [c0, c1] = simple_ordinary_least_squares(log_nparticles, log_summed_error);
+  //std::cout << "f(x) = " << c0 << " + " << c1 << "*x" << "\n";
 
   // summed error should decay like nparticles^{-1/2}
-
-  for(int j = 0; j < 20; j++){
-	  std::cout << summed_error[j] << " ";
-  }
-
-
-  EXPECT_EQ(mesh.t, 0.0);
-  EXPECT_EQ(mesh.dt, 0.01);
-  EXPECT_EQ(mesh.nt, 1000);
-  EXPECT_EQ(mesh.nintervals, 10);
-  EXPECT_EQ(mesh.nmesh, 11);
-  EXPECT_EQ(mesh.mesh.size(), mesh.nmesh);
-  EXPECT_EQ(mesh.dx, 0.1);
-  for(int i = 0; i < mesh.mesh.size(); i++){
-  	EXPECT_EQ(mesh.mesh.at(i), double(i)*mesh.dx);
-  }
-  EXPECT_EQ(mesh.mesh_staggered.size(), mesh.nintervals);
-  for(int i = 0; i < mesh.mesh_staggered.size(); i++){
-  	EXPECT_EQ(mesh.mesh_staggered.at(i), double(i+0.5)*mesh.dx);
-  }
+  ASSERT_NEAR(c1, -0.5, 0.05);
 }
 


### PR DESCRIPTION
This add a test that makes the initial conditions for particles, deposits the particles onto the grid, and calculates the resulting electric field. The difference between the calculated field, and the exact field implied by the initial conditions should decrease like 1/sqrt(number of particles).

This test runs this for a few different particle counts and checks the convergence. (That's why I've called this an MMS test, because it has the structure used by mms tests...)  