### PR TITLE
Make velocity a structure of arrays

### DIFF
--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -51,7 +51,7 @@ void Diagnostics::compute_particle_energy(Plasma *plasma) {
 
 	double energy = 0.0;
 	for( std::size_t i = 0; i < plasma->n; i++) {
-		energy += plasma->w.at(i)*std::pow(plasma->v.at(i),2);
+		energy += plasma->w.at(i)*std::pow(plasma->v.x.at(i),2);
 	}
 	energy *= 0.5;
 

--- a/src/plasma.cpp
+++ b/src/plasma.cpp
@@ -20,7 +20,9 @@ Plasma::Plasma(int n_in, double T_in) {
 	T = T_in;
 
 	x.resize(n); // particle positions
-	v.resize(n); // particle velocities
+	v.x.resize(n); // particle velocities
+	v.y.resize(n); // particle velocities
+	v.z.resize(n); // particle velocities
 	
 	set_initial_conditions(x, v);
 
@@ -35,7 +37,7 @@ Plasma::Plasma(int n_in, double T_in) {
  * Pick random triplet (pos, vel, r) and keep particle if r < f(x,v)
  * for f the initial distribution.
  */
-void Plasma::set_initial_conditions(std::vector<double> &x, std::vector<double> &v) {
+void Plasma::set_initial_conditions(std::vector<double> &x, Velocity &v) {
 
 	// trial particle positions and velocities
 	double pos, vel, r;
@@ -57,7 +59,9 @@ void Plasma::set_initial_conditions(std::vector<double> &x, std::vector<double> 
 		//if( r < 0.5 * big * ( exp(- big*(vel-0.5)*(vel-0.5)) + exp(- big*(vel+0.5)*(vel+0.5)) )) {
 		if( r < 0.5 * big * ( exp(- big*(vel-1.0)*(vel-1.0)) + exp(- big*(vel+1.0)*(vel+1.0)) )) {
 			x.at(i) = pos;
-			v.at(i) = vel;
+			v.x.at(i) = vel;
+			v.y.at(i) = 0.0;
+			v.z.at(i) = 0.0;
 			i++;
 		}
 	}
@@ -70,8 +74,8 @@ void Plasma::set_initial_conditions(std::vector<double> &x, std::vector<double> 
 void Plasma::push(Mesh *mesh) {
 
 	for(int i = 0; i < n; i++) {
-         	v.at(i) += 0.5 * mesh->dt * mesh->evaluate_electric_field(x.at(i));
-         	x.at(i) += mesh->dt * v.at(i);
+         	v.x.at(i) += 0.5 * mesh->dt * mesh->evaluate_electric_field(x.at(i));
+         	x.at(i) += mesh->dt * v.x.at(i);
 
 		//apply periodic bcs
 		while(x.at(i) < 0){
@@ -79,7 +83,7 @@ void Plasma::push(Mesh *mesh) {
 		}
                 x.at(i) = std::fmod(x.at(i), 1.0);
 
-         	v.at(i) += 0.5 * mesh->dt * mesh->evaluate_electric_field(x.at(i));
+         	v.x.at(i) += 0.5 * mesh->dt * mesh->evaluate_electric_field(x.at(i));
 
 	}
 }

--- a/src/plasma.hpp
+++ b/src/plasma.hpp
@@ -5,6 +5,17 @@ class Plasma;
 
 #include "mesh.hpp"
 
+class Velocity {
+public:
+	// particle velocity array in x direction
+	std::vector<double> x;
+	// particle velocity array in r direction
+	std::vector<double> y;
+	// particle velocity array in z direction
+	std::vector<double> z;
+};
+
+
 class Plasma {
 public:
 	Plasma(int n = 10, double T = 1.0);
@@ -14,8 +25,8 @@ public:
 	double T;
 	// particle position array
 	std::vector<double> x;
-	// particle velocity array
-	std::vector<double> v;
+	// particle velocity structure of arrays
+	Velocity v;
 	// particle position array at
 	// next timestep
 	std::vector<double> xnew;
@@ -27,7 +38,7 @@ public:
 	// particle pusher
 	void push(Mesh *mesh);
 	// initial conditions 
-	void set_initial_conditions(std::vector<double> &x, std::vector<double> &v);
+	void set_initial_conditions(std::vector<double> &x, Velocity &v);
 };
 
 #endif // __PLASMA_H__

--- a/test/plasma_test.cc
+++ b/test/plasma_test.cc
@@ -41,7 +41,9 @@ TEST(PlasmaTest, InitialConditions) {
 	for(int i = 0; i < plasma.n; i++){
 		EXPECT_TRUE( plasma.x[i] >= 0.0 );
 		EXPECT_TRUE( plasma.x[i] <= 1.0 );
-		EXPECT_TRUE( plasma.v[i] >= -6.0 );
-		EXPECT_TRUE( plasma.v[i] <= 6.0 );
+		EXPECT_TRUE( plasma.v.x[i] >= -6.0 );
+		EXPECT_TRUE( plasma.v.x[i] <= 6.0 );
+		EXPECT_TRUE( plasma.v.y[i] == 0.0 );
+		EXPECT_TRUE( plasma.v.z[i] == 0.0 );
 	}
 }


### PR DESCRIPTION
Start to make the code 3D in velocity by change from a single v array to a structure of velocity arrays. This is still effectively 1D in x though as both the y and z velocities are set to 0 and ignored in the pusher.

Question: how should I treat the diagnostics? Particle energy generalizes to `w*(v.x^2 + v.y^2 + v.z^2)`, but is is worth splitting this up and separately tracking the values of `w*v.x^2`, `w*v.y^2` and `w*v.z^2`?