### PR TITLE
Add and run black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+black==22.3.0
+click==8.1.3
 cmake-format==0.6.13
 cmakelang==0.6.13
+mypy-extensions==0.4.3
+pathspec==0.9.0
+platformdirs==2.5.2
 six==1.16.0
+tomli==2.0.1
+typing-extensions==4.2.0


### PR DESCRIPTION
# Description

We need a "please format everything script" and we'll want `black` in that for python formatting. Hence this PR.

 - I've added black to the PR template how-to section.
 - I've run black against the python dir.
 - Black is now in requirements.txt

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] API change (breaks downstream workflows and requires major semver bump)
- [ ] Requires documentation updates

