### PR TITLE
README hipsycl@0.9.1 -> hipsycl@0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ different code components.
 A relatively straightforward way of installing the dependencies is via spack, but be aware that this will take several hours!
 
 ```
-spack install hipsycl@0.9.1 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
-spack load hipsycl@0.9.1 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
+spack install hipsycl@0.9.2 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
+spack load hipsycl@0.9.2 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
 ```
 
 ### CMake 


### PR DESCRIPTION
Update README to document spack install of latest hipsycl version.

# Description

README suggested installing not the most recent version of hipsycl. We should install the latest one - this PR fixes it.

## Type of change

- [x] Requires documentation updates

# Testing

Will has been using hipsycl@0.9.2

**Test Configuration**:

* OS:
* SYCL implementation:
* MPI details:
* Hardware:

# Checklist:

 - [x] Change to README