### PR TITLE
Init mpi testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+# find MPI
+find_package(MPI REQUIRED)
+
 # Include hipSYCL
 find_package(hipSYCL 0.9.2 QUIET)
 if(NOT hipSYCL_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,12 +44,11 @@ set(EXECUTABLE testNESO)
 
 set(TEST_MAIN ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-message("TEST_MAIN " ${TEST_MAIN})
+find_package(MPI REQUIRED)
 
 # List test source files
 file(GLOB TEST_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp)
-message(STATUS ${TEST_SRCS})
 
 # Build the tests individually
 include(GoogleTest)
@@ -57,7 +56,6 @@ foreach(TEST ${TEST_SRCS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
   message(STATUS "Found test - ${TEST_NAME}")
   set(TEST_LIST ${TEST_LIST} ${TEST_NAME})
-  # message( STATUS "Test list - ${TEST_LIST}" )
 
   set(TEST_SOURCES ${TEST_MAIN} ${TEST})
   add_executable(${TEST_NAME} ${TEST_SOURCES})
@@ -66,11 +64,12 @@ foreach(TEST ${TEST_SRCS})
   if(MKL_FOUND)
     target_link_libraries(
       ${TEST_NAME} PRIVATE ${LIBRARY_NAME} gtest lapack ${CUSTOM_MKL_LINK}
-                           ${Boost_LIBRARIES})
+      ${Boost_LIBRARIES} ${MPI_CXX_LINK_FLAGS} ${MPI_CXX_LIBRARIES})
     target_include_directories(
       ${TEST_NAME}
       PRIVATE ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIRS}
-              $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+              $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>
+               ${MPI_CXX_INCLUDE_PATH})
     target_compile_options(
       ${TEST_NAME} PUBLIC -fsycl
                           $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
@@ -79,10 +78,11 @@ foreach(TEST ${TEST_SRCS})
   if(FFTW_FOUND)
     target_link_libraries(
       ${TEST_NAME} PRIVATE gtest ${LIBRARY_NAME} PkgConfig::FFTW
-                           ${Boost_LIBRARIES} -ltbb)
+      ${Boost_LIBRARIES} -ltbb  ${MPI_CXX_LINK_FLAGS}  ${MPI_CXX_LIBRARIES})
     target_include_directories(
       ${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIRS}
-                           PkgConfig::FFTW)
+                           PkgConfig::FFTW
+                            ${MPI_CXX_INCLUDE_PATH})
   endif()
 
   add_sycl_to_target(TARGET ${TEST_NAME} SOURCES ${TEST_SOURCES})
@@ -102,10 +102,11 @@ if(MKL_FOUND)
   target_include_directories(
     ${EXECUTABLE}
     PRIVATE ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIRS}
-            $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+            $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>
+             ${MPI_CXX_INCLUDE_PATH})
   target_link_libraries(
     ${EXECUTABLE} PRIVATE gtest lapack ${Boost_LIBRARIES} sycl
-                          ${CUSTOM_MKL_LINK})
+    ${CUSTOM_MKL_LINK} ${MPI_CXX_LINK_FLAGS}  ${MPI_CXX_LIBRARIES})
   target_compile_options(
     ${EXECUTABLE} PUBLIC -fsycl
                          $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
@@ -114,10 +115,11 @@ endif()
 if(FFTW_FOUND)
   target_include_directories(
     ${EXECUTABLE} PRIVATE ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIRS}
-                          PkgConfig::FFTW)
+                          PkgConfig::FFTW
+                           ${MPI_CXX_INCLUDE_PATH})
   target_link_libraries(
     ${EXECUTABLE} PRIVATE gtest ${Boost_LIBRARIES} PkgConfig::FFTW
-                          -ltbb)
+    -ltbb  ${MPI_CXX_LINK_FLAGS}  ${MPI_CXX_LIBRARIES})
 endif()
 
 # define the test executable as a sycl target

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,32 @@
 #include "gtest/gtest.h"
+#include <iostream>
+#include <mpi.h>
+
+/*
+ *  If an exception is thrown try and abort MPI cleanly to prevent a deadlock.
+ */
+void TerminateHandler() {
+  std::cout << "Exception thrown attempting to abort cleanly." << std::endl;
+  MPI_Abort(MPI_COMM_WORLD, -2);
+}
+
 int main(int argc, char **argv) {
+
+  if (MPI_Init(&argc, &argv) != MPI_SUCCESS) {
+    std::cout << "ERROR: MPI_Init != MPI_SUCCESS" << std::endl;
+    return -1;
+  }
+
+#if GTEST_HAS_EXCEPTIONS
+  std::set_terminate(&TerminateHandler);
+#endif
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int err = RUN_ALL_TESTS();
+
+  if (MPI_Finalize() != MPI_SUCCESS) {
+    std::cout << "ERROR: MPI_Finalize != MPI_SUCCESS" << std::endl;
+    return -1;
+  }
+
+  return err;
 }


### PR DESCRIPTION
# Description

Adds calls to MPI_Iinit/Finalize such that are called only once per binary. Adds MPI to the CMake file for tests.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality) : Allows MPI in tests.

# Testing

Current tests pass with mpich-4.0 + hipsycl-0.9.2 and intelmpi-2021.6 + dpcpp-2022.1

**Test Configuration**:

* OS: ubuntu 22.04
* SYCL implementation: see above
* MPI details: see above
* Hardware: intel i9-10920x