### PR TITLE
Set up spack environment to handle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ include/revision.hpp
 *.sw*
 **/*.fld
 **/*.opt
+*~
+.spack-env
+spack-build-*.txt
+spack-configure-args.txt
+spack-build-*/
+install-time-test-log.txt
+spack.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "NESO-Spack"]
+	path = NESO-Spack
+	url = https://github.com/ExCALIBUR-NEPTUNE/NESO-Spack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,11 @@ add_executable(${PROJECT_NAME} ${MAIN_SRC})
 # define the source file objects as a sycl targets
 add_sycl_to_target(TARGET ${LIBRARY_NAME} SOURCES ${LIB_SRCS})
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-error=unused-command-line-argument)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+  set(UNUSED_ARG -Wno-error=unused-command-line-argument)
+  message(${UNUSED_ARG})
+endif()
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror ${UNUSED_ARG})
 # target_compile_options( ${PROJECT_NAME} PUBLIC
 # $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,19 @@ message(STATUS "Found Nektar++: version ${NEKTAR++_VERSION}")
 # Set RPATH for wherever Nektar++ is installed.
 set(CMAKE_INSTALL_RPATH "${NEKTAR++_LIBRARY_DIRS}")
 
+# Hack to deal with the fact Intel seems to be inconsistent with
+# whether it prefers you to use dpcpp or icpx directly. MKL requires
+# the compiler to be dpcpp, but the DPCPP cmake files actually prefer
+# that icpx is used.
+if (CMAKE_CXX_COMPILER MATCHES "icpx$")
+  message("REGEX evaluated true")
+  set(CMAKE_CXX_COMPILER_ORIGINAL ${CMAKE_CXX_COMPILER})
+  set(CMAKE_CXX_COMPILER "dpcpp")
+endif()
 find_package(MKL CONFIG QUIET)
+if (CMAKE_CXX_COMPILER_ORIGINAL)
+  set(CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER_ORIGINAL})
+endif()
 if(MKL_FOUND)
 
   # Documented manner to link against mkl.
@@ -131,7 +143,7 @@ add_executable(${PROJECT_NAME} ${MAIN_SRC})
 # define the source file objects as a sycl targets
 add_sycl_to_target(TARGET ${LIBRARY_NAME} SOURCES ${LIB_SRCS})
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-error=unused-command-line-argument)
 # target_compile_options( ${PROJECT_NAME} PUBLIC
 # $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,16 @@ message(STATUS "Found Nektar++: version ${NEKTAR++_VERSION}")
 # Set RPATH for wherever Nektar++ is installed.
 set(CMAKE_INSTALL_RPATH "${NEKTAR++_LIBRARY_DIRS}")
 
-# Hack to deal with the fact Intel seems to be inconsistent with
-# whether it prefers you to use dpcpp or icpx directly. MKL requires
-# the compiler to be dpcpp, but the DPCPP cmake files actually prefer
-# that icpx is used.
-if (CMAKE_CXX_COMPILER MATCHES "icpx$")
+# Hack to deal with the fact Intel seems to be inconsistent with whether it
+# prefers you to use dpcpp or icpx directly. MKL requires the compiler to be
+# dpcpp, but the DPCPP cmake files actually prefer that icpx is used.
+if(CMAKE_CXX_COMPILER MATCHES "icpx$")
   message("REGEX evaluated true")
   set(CMAKE_CXX_COMPILER_ORIGINAL ${CMAKE_CXX_COMPILER})
   set(CMAKE_CXX_COMPILER "dpcpp")
 endif()
 find_package(MKL CONFIG QUIET)
-if (CMAKE_CXX_COMPILER_ORIGINAL)
+if(CMAKE_CXX_COMPILER_ORIGINAL)
   set(CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER_ORIGINAL})
 endif()
 if(MKL_FOUND)
@@ -143,11 +142,12 @@ add_executable(${PROJECT_NAME} ${MAIN_SRC})
 # define the source file objects as a sycl targets
 add_sycl_to_target(TARGET ${LIBRARY_NAME} SOURCES ${LIB_SRCS})
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
   set(UNUSED_ARG -Wno-error=unused-command-line-argument)
   message(${UNUSED_ARG})
 endif()
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror ${UNUSED_ARG})
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror
+                                               ${UNUSED_ARG})
 # target_compile_options( ${PROJECT_NAME} PUBLIC
 # $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ set(CMAKE_INSTALL_RPATH "${NEKTAR++_LIBRARY_DIRS}")
 # prefers you to use dpcpp or icpx directly. MKL requires the compiler to be
 # dpcpp, but the DPCPP cmake files actually prefer that icpx is used.
 if(CMAKE_CXX_COMPILER MATCHES "icpx$")
-  message("REGEX evaluated true")
   set(CMAKE_CXX_COMPILER_ORIGINAL ${CMAKE_CXX_COMPILER})
   set(CMAKE_CXX_COMPILER "dpcpp")
 endif()

--- a/README.md
+++ b/README.md
@@ -6,20 +6,94 @@ different code components.
 ## Dependencies
 
 * CMake
-* Boost >= 1.78 (for tests)
+* Boost >= 1.74 (for tests)
 * SYCL implementation Hipsycl and fftw or OneAPI and MKL.
 * Nektar++
 
-### Building dependencies with Spack
+### Building with Spack
 
-A relatively straightforward way of installing the dependencies is via spack, but be aware that this will take several hours!
+The easiest way to install NESO is using the
+[Spack package manager](https://spack.readthedocs.io/en/latest/index.html), although
+this can take a few hours the first time you do it or if you change
+compilers. This repository has been set up so you can use a
+variation of the [Spack developer
+workflow](https://spack-tutorial.readthedocs.io/en/latest/tutorial_developer_workflows.html). Simply
+run the following commands at the top level of the repository:
 
+```bash
+git submodule update --init  # Probably not necessary, but just to be safe
+spack env activate -p -d .
+spack install
 ```
-spack install hipsycl@0.9.2 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
-spack load hipsycl@0.9.2 boost@1.78.0 llvm-openmp@12.0.1 fftw@3.3.10
-```
 
-### CMake 
+This creates an [anonymous Spack
+environment](https://spack.readthedocs.io/en/latest/environments.html#anonymous-environments)
+based on the settings in [the spack.yaml file](spack.yaml). These
+configurations tell Spack to install NESO and all of its
+dependencies. Rather
+than pulling fresh NESO source code from GitHub,
+it will use the copy of the code in your current working
+directory. These packages will be installed in the usual Spack
+locations. They will also be linked into a ["filesystem
+view"](https://spack.readthedocs.io/en/latest/environments.html#filesystem-views)
+located at `.spack-env/view/`. Environment variables such as `PATH`
+and `CMAKE_PREFIX_PATH` were updated to include the view directory and
+its subdirectories when you called `spack env activate...`.
+
+The NESO build will be done in a directory called something
+like `spack-build-6gyyv2t` (the hash may differ).  FFTW and hipSYCL
+will be used; OneAPI currently isn't supported in Spack (but hopefully
+will be soon). It will also build NESO for you in a directory called
+something like `spack-build-6gyyv2t` (the exact hash may
+differ). Binaries, however, are placed in the `bin` directory at the
+top level of the repository. They are not currently installed. This is
+likely to change in future.
+
+As you develop the code, there are a few options for how you
+recompile. One is simply to run `spack install` again. This will
+reuse the existing build directory and reinstall the results of the
+build. The build environment used is determined by the packages
+configuration for NESO (as specificed in the NESO [package
+repository](https://github.com/ExCALIBUR-NEPTUNE/NESO-Spack) and is
+the same as if you were doing a traditional Spack installation of a
+named version of NESO. The main disadvantage of this approach is that
+Spack hides the output of CMake during the build process and will only
+show you any information on the build if there is an error. This means
+you will likely miss any compiler warnings, unless you check the build
+logs.
+
+An alternative approach is to prefix your usual build commands with
+`spack build-env neso`. This will cause the commands to be run in the
+same build environment used for `spack install`. For example, you
+could run
+
+```bash
+spack build-env neso cmake . -B build
+spack build-env neso cmake --build build
+```
+This would cause the build to occur in the directory `build`. This
+approach works quite well. The only slight downside is the commands are
+a bit cumbersome.
+
+Finally, you can take advantage of the fact that the filesystem view
+which was loaded when you activated the environment gives you access
+to all of the resources for the build that you need. As such, you
+could just run
+
+```bash
+cmake . -B build
+cmake --build build
+```
+CMake will automatically be able to find all of the packages it needs
+in `.spack-env/view/`. The downside of this approach is that there is
+a small risk CMake will end up using a different compiler or compiler
+version than was used to build all of the dependencies. You should
+ensure you are aware of what compilers you have installed and, if
+necessary, explicitely specify to CMake which you want to use.
+
+### Manually Installing Dependencies
+
+#### CMake 
 
 Ensure a recent version of [CMake](https://cmake.org/download/) is available.
 If necessary, install with
@@ -32,7 +106,7 @@ cd cmake-3.23.1/
 make
 ```
 
-### Boost
+#### Boost
 
 The test suite requires the [Boost library](https://www.boost.org/) (version >= 1.78).
 If this is not available on your system, this can be build from source by doing
@@ -52,7 +126,7 @@ install dir at configure time:
 cmake -DBoost_INCLUDE_DIR=/path/to/boost_1_79_0/ . -B build
 ```
 
-### Nektar++
+#### Nektar++
 
 To build with Nektar++, ensure that Nektar++ is installed on your system.
 There are instructions on the 
@@ -83,7 +157,7 @@ the `Nektar++Config.cmake` file.
 Note that for this file to exist, you must do `make install` at the end of the
 Nektar++ build.
 
-### NEPTUNE
+### Manually building NEPTUNE
 
 To build the code and the tests, do
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ make
 
 #### Boost
 
-The test suite requires the [Boost library](https://www.boost.org/) (version >= 1.78).
+The test suite requires the [Boost library](https://www.boost.org/) (version >= 1.74).
 If this is not available on your system, this can be build from source by doing
 
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ differ). Binaries, however, are placed in the `bin` directory at the
 top level of the repository. They are not currently installed. This is
 likely to change in future.
 
+Note: When building with the Intel OneAPI compilers, you need to have
+the GCC 12 version of the C++ standard library installed on your
+machine. On Ubuntu, run `apt-get install libstdc++-12-dev`.
+
 As you develop the code, there are a few options for how you
 recompile. One is simply to run `spack install` again. This will
 reuse the existing build directory and reinstall the results of the

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   # add package specs to the `specs` list
   specs:
   - neso%gcc ^openblas ^hipsycl
-  #- neso%oneapi ^nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel ^py-cython%oneapi ^dpcpp
+  #- neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel ^py-cython%oneapi ^dpcpp
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,21 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs: [neso]
+  view: true
+  concretizer:
+    unify: true
+  repos:
+  - ./NESO-Spack
+  - $spack/var/spack/repos/builtin
+  packages:
+    all:
+      providers:
+        mpi: [mpich, openmpi]
+  develop:
+    neso:
+      path: .
+      spec: neso@working

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,7 +1,7 @@
 # This is a Spack Environment file.
 #
-# It describes a set of packages to be installed, along with
-# configuration settings.
+# It describes the set of packages to be installed when developing
+# NESO, along with configuration settings.
 spack:
   # add package specs to the `specs` list
   specs: [neso]
@@ -15,6 +15,7 @@ spack:
     all:
       providers:
         mpi: [mpich, openmpi]
+        sycl: [dpcpp, hipsycl]
   develop:
     neso:
       path: .

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,8 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - neso%gcc ^openblas
-  #- neso%oneapi ^nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel ^py-cython%oneapi
+  - neso%gcc ^openblas ^hipsycl
+  #- neso%oneapi ^nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel ^py-cython%oneapi ^dpcpp
   view: true
   concretizer:
     unify: true
@@ -17,7 +17,6 @@ spack:
     all:
       providers:
         mpi: [mpich, openmpi]
-        sycl: [dpcpp, hipsycl]
   develop:
     neso:
       path: .

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,9 @@
 # NESO, along with configuration settings.
 spack:
   # add package specs to the `specs` list
-  specs: [neso]
+  specs:
+  - neso%gcc ^openblas
+  #- neso%oneapi ^nektar%oneapi ^intel-oneapi-mkl ^py-numpy%intel ^boost%intel ^py-cython%oneapi
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
# Description

The current build instructions are a bit ad-hoc. I have attempted to make the build process more robust using Spack. In particular, I have added a `spack.yaml` file which defines a custom [Spack environment](https://spack-tutorial.readthedocs.io/en/latest/tutorial_environments.html) to be [used for development](https://spack-tutorial.readthedocs.io/en/latest/tutorial_developer_workflows.html). 

Addressed (at least partially) #3, #20, relates to #86.

## Type of change

- [x] Build system improvements
- [x] Requires documentation updates

# Testing

The build was executed and confirmed to work on my laptop. The resulting test binaries which were built were run and all passed.

**Test Configuration**:

* OS: Linux Mint 21 (Ubuntu 22.04)
* SYCL implementation: HipSYCL 0.9.2, DPC++ 2022.1.0
* MPI details: MPICH 4.0.2
* Hardware: Intel Icelake

# Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any new dependencies are automatically built for users via `cmake`
- [x] I have used understandable variable names
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [x] I have run `black` against changes to `*.py`
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings