### PR TITLE
switched from gtest_discover_tests to gtest_add_tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,8 +103,7 @@ foreach(TEST ${TEST_SRCS})
   endif()
 
   add_sycl_to_target(TARGET ${TEST_NAME} SOURCES ${TEST_SOURCES})
-  gtest_discover_tests(${TEST_NAME} DISCOVERY_TIMEOUT 600)
-
+  gtest_add_tests(TARGET ${TEST_NAME} SOURCES ${TEST_SOURCES})
 endforeach()
 
 # Build a global test suite
@@ -136,4 +135,4 @@ endif()
 # define the test executable as a sycl target
 add_sycl_to_target(TARGET ${EXECUTABLE} SOURCES ${TEST_MAIN} ${TEST_LIST}
                    ${SRC_LIST})
-gtest_discover_tests(${EXECUTABLE} DISCOVERY_TIMEOUT 600)
+gtest_add_tests(TARGET ${EXECUTABLE} SOURCES ${TEST_MAIN})


### PR DESCRIPTION
# Description

Switches from `gtest_discover_tests` to `gest_add_tests` in the test cmake lists.

The issue is that often tests cannot be run in the build environment, e.g. HPC facilities where mpiexec is not available on compute nodes or intel MPI + docker which may require additional environment variables to be set to work properly. Google test offers this alternative method to find tests that greps the source files for gtest macros to discover the tests. This stops the build from failing because the test binary could not be run. I have been using this method in NESO-Particles without issue.

## Type of change

- Quality of life.

# Testing

Ran the existing tests.

**Test Configuration**:

* OS: ubuntu 22.04
* SYCL implementation: hipsycl 0.92
* MPI details: mpich 4.0
* Hardware: generic intel

# Checklist:

- [* ] I have run `cmake-format` against my changes to `CMakeLists.txt`
