### PR TITLE
Trivial change to fix a build warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,4 +50,4 @@ int main() {
   }
 
   return 0;
-};
+}


### PR DESCRIPTION
 Trivial change to remove a superfluous semi-colon at the end of the main function, which was causing a build error.

## Type of change

Please delete options that are not relevant.
- [x ] Bug fix (non-breaking change)

# Checklist:
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] My changes generate no new warnings
