### PR TITLE
Use Scotch version 6 to avoid a seg fault in Nektar

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,8 +6,8 @@ spack:
   # add package specs to the `specs` list
   specs:
   - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl ^py-numpy%intel
-    ^boost%intel ^py-cython%oneapi ^dpcpp
-  - neso%gcc ^openblas ^hipsycl
+    ^boost%intel ^py-cython%oneapi ^dpcpp ^scotch@6
+  - neso%gcc ^openblas ^hipsycl ^scotch@6
   view:
     gcc-hipsycl:
       root: views/gcc-hipsycl


### PR DESCRIPTION
# Description

Fixes the Scotch version to 6 in the gcc-hipsycl and oneapi-dpcc spack specs.

Fixes #137

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change)

# Testing

All unit and integration tests pass with both gcc-hipsycl and oneapi-dpcpp, in particular, SimpleSOLTest.2D no longer seg faults.

**Test Configuration**:

* OS: Ubuntu 22.04
* Compiler: GCC 11.3.0 / OneAPI v2022.1.0
* SYCL implementation: Hipsycl v0.9.2 / DPC++ v2022.1.0
* MPI details: MPICH v4.0.2
* Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings