### PR TITLE
Tweaks to the 'activate' script

### DIFF
--- a/activate
+++ b/activate
@@ -180,7 +180,7 @@ monitor-build-dirs() {
 cleanup() {
     cleanup-deprecated-builds neso "${NESO_DEV_DIR}"
     cleanup-deprecated-builds nektar "${NESO_DEV_DIR}/nektar"
-    cleanup-deprecated-builds nektar "${NESO_DEV_DIR}/nerso-particles"
+    cleanup-deprecated-builds neso-particles "${NESO_DEV_DIR}/neso-particles"
 }
 
 spack env activate -p -d ${NESO_DEV_DIR}

--- a/activate
+++ b/activate
@@ -16,7 +16,7 @@ deactivate() {
   then
       kill $__MONITOR_PROCESS
   fi
-  ps -ef | grep "spack find -l neso nektar" | grep -v grep | awk '{print $2}' | xargs kill -9
+  ps -ef | grep "spack find -l neso nektar neso-particles" | grep -v grep | awk '{print $2}' | xargs kill -9
 
   # Tidy up environment variables
   export I_MPI_FABRICS=$__ORIGINAL_I_MPI_FABRICS
@@ -171,7 +171,7 @@ monitor-build-dirs() {
     trap 
     while :
     do
-        watch -n10 -g spack find -l neso nektar &> /dev/null && setup &> /dev/null
+        watch -n10 -g spack find -l neso nektar neso-particles &> /dev/null && setup &> /dev/null
     done
 }
 

--- a/activate
+++ b/activate
@@ -34,6 +34,7 @@ deactivate() {
   unset -f create-link
   unset -f link-nektar-builds
   unset -f link-neso-builds
+  unset -f link-neso-particles-builds
   unset -f setup
   unset -f monitor-build-dirs
 


### PR DESCRIPTION
# Description

Minor changes to the activate script, including correcting a path to neso-particles build dirs in the cleanup function and adding neso-particles to the list of monitored build dirs. 

## Type of change

- [x] Bug fix (non-breaking change)

# Testing

Checked that cleanup works for neso-particles build dirs.

**Test Configuration**:

* OS: Ubuntu 22.04
* Compiler: GCC 11.3.0 / OneAPI v2022.1.0
* SYCL implementation: Hipsycl v0.9.2 / DPC++ v2022.1.0
* MPI details: MPICH v4.0.2
* Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
