### PR TITLE
Ionisation kernel for the coupled-2D3V simplesol + neutrals milesone

### DIFF
--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
@@ -36,10 +36,8 @@
 
 #include "SOLSystem.h"
 
-using namespace std;
-
 namespace Nektar {
-string SOLSystem::className =
+std::string SOLSystem::className =
     SolverUtils::GetEquationSystemFactory().RegisterCreatorFunction(
         "SOL", SOLSystem::create, "SOL equations in conservative variables.");
 
@@ -98,7 +96,7 @@ void SOLSystem::InitAdvection() {
   ASSERTL0(m_projectionType == MultiRegions::eDiscontinuous,
            "Unsupported projection type: must be DG.");
 
-  string advName, riemName;
+  std::string advName, riemName;
   m_session->LoadSolverInfo("AdvectionType", advName, "WeakDG");
 
   m_advObject =
@@ -522,11 +520,11 @@ Array<OneD, NekDouble> SOLSystem::GetElmtMinHP(void) {
 
     LocalRegions::Expansion1DSharedPtr exp1D;
     exp1D = m_fields[0]->GetExp(e)->as<LocalRegions::Expansion1D>();
-    h = min(h, exp1D->GetGeom1D()->GetVertex(0)->dist(
+    h = std::min(h, exp1D->GetGeom1D()->GetVertex(0)->dist(
                    *(exp1D->GetGeom1D()->GetVertex(1))));
 
     // Determine h/p scaling
-    hOverP[e] = h / max(pOrderElmt[e] - 1, 1);
+    hOverP[e] = h / std::max(pOrderElmt[e] - 1, 1);
   }
 
   return hOverP;

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -34,8 +34,6 @@
 
 #include "SOLWithParticlesSystem.h"
 
-using namespace std;
-
 namespace Nektar {
 string SOLWithParticlesSystem::className =
     SolverUtils::GetEquationSystemFactory().RegisterCreatorFunction(
@@ -68,6 +66,7 @@ void SOLWithParticlesSystem::v_InitObject(bool DeclareField) {
  */
 SOLWithParticlesSystem::~SOLWithParticlesSystem() { m_particle_sys.free(); }
 
+
 /**
  * @brief Compute the right-hand side.
  */
@@ -77,6 +76,22 @@ void SOLWithParticlesSystem::DoOdeRhs(
 
   // Integrate the particle system to the requested time.
   m_particle_sys.integrate(time, m_part_timestep);
+  // TODO project onto the fields
+
+  // Neutrals have been ionised, so no project onto the  delta_rho field
+  // ...
+  // Now do rho = rho + delta_rho
+  //const int rho_index = this->GetFieldIndex("rho");
+  //const int delta_rho_index = this->GetFieldIndex("delta_rho");
+  //Vmath::Vadd(m_fields[rho_index]->GetTotPoints(),
+  //            m_fields[rho_index]->UpdateCoeffs(), 1
+  //            m_fields[delta_rho_index]->UpdatePhys(), 1,
+  //            m_fields[rho_index]->UpdateCoeffs(), 1); // TODO is this right?
+  //now zero the delta_rho field
+  //  Vmath::Zero(m_fields[delta_rho_index]->GetTotPoints(),
+  //              m_fields[delta_rho_index]->UpdatePhys(), 1);
+  // TODO momentum and energy sources
+  // Now density source is done do the rest
 
   SOLSystem::DoOdeRhs(inarray, outarray, time);
 }


### PR DESCRIPTION
I'm on annual leave from end of play today until Monday 20th, so I thought I'd get this visible for merging / cherry picking into the other branches.

This code is **buildable, but won't run**.

The boost and stl implementations of the exponential integral function required by the ionisation kernel won't compile, so I've added the Barry et al approximation, see https://en.wikipedia.org/wiki/Exponential_integral#Approximations. I haven't checked its range of applicability or it's error bounds. See also #150.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.
 
**No tests have been implemented yet**

**Test Configuration**:

* OS: Ubuntu 22.04
* SYCL implementation: hipsycl and onapi
* MPI details: n/a
* Hardware: intel i9

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new dependencies are automatically built for users via `cmake`
- [ ] I have used understandable variable names
- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [ ] I have run `black` against changes to `*.py`
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

