### PR TITLE
Modify SOLSolver to allow modifications of fields in the timestep loop

### DIFF
--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -8,7 +8,7 @@
         <PARAMETERS>
             <P> TimeStep       = 5e-3        </P>
             <P> NumSteps       = 800       </P>
-            <P> IO_CheckSteps  = NumSteps+1 </P>
+            <P> IO_CheckSteps  = NumSteps/100 </P>
             <P> IO_InfoSteps   = NumSteps+1  </P>
             <P> Gamma          = 5.0/3.0     </P>
             <P> GasConstant    = 1.0         </P>

--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
@@ -234,7 +234,7 @@ void SOLSystem::v_DoSolve() {
 
   // Order storage to list time-integrated fields first.
   for (i = 0; i < nvariables; ++i) {
-    fields[i] = m_fields[m_intVariables[i]]->GetPhys();
+    fields[i] = m_fields[m_intVariables[i]]->UpdatePhys();
     m_fields[m_intVariables[i]]->SetPhysState(false);
   }
 

--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
@@ -32,6 +32,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <LibUtilities/TimeIntegration/TimeIntegrationScheme.h>
 #include <boost/core/ignore_unused.hpp>
 
 #include "SOLSystem.h"
@@ -195,6 +196,335 @@ void SOLSystem::DoOdeProjection(
   for (int i = 0; i < nvariables; ++i) {
     Vmath::Vcopy(npoints, inarray[i], 1, outarray[i], 1);
     SetBoundaryConditions(outarray, time);
+  }
+}
+
+/**
+ * @brief Initialises the time integration scheme (as specified in the
+ * session file), and perform the time integration.
+ */
+void SOLSystem::v_DoSolve() {
+  ASSERTL0(m_intScheme != 0, "No time integration scheme.");
+
+  int i = 1;
+  int nvariables = 0;
+  int nfields = m_fields.size();
+
+  if (m_intVariables.empty()) {
+    for (i = 0; i < nfields; ++i) {
+      m_intVariables.push_back(i);
+    }
+    nvariables = nfields;
+  } else {
+    nvariables = m_intVariables.size();
+  }
+
+  // Integrate in wave-space if using homogeneous1D
+  if (m_HomogeneousType != eNotHomogeneous && m_homoInitialFwd) {
+    for (i = 0; i < nfields; ++i) {
+      m_fields[i]->HomogeneousFwdTrans(m_fields[i]->GetPhys(),
+                                       m_fields[i]->UpdatePhys());
+      m_fields[i]->SetWaveSpace(true);
+      m_fields[i]->SetPhysState(false);
+    }
+  }
+
+  // Set up wrapper to fields data storage.
+  Array<OneD, Array<OneD, NekDouble>> fields(nvariables);
+
+  // Order storage to list time-integrated fields first.
+  for (i = 0; i < nvariables; ++i) {
+    fields[i] = m_fields[m_intVariables[i]]->GetPhys();
+    m_fields[m_intVariables[i]]->SetPhysState(false);
+  }
+
+  // Initialise time integration scheme
+  m_intScheme->InitializeScheme(m_timestep, fields, m_time, m_ode);
+
+  // Initialise filters
+  for (auto &x : m_filters) {
+    x.second->Initialise(m_fields, m_time);
+  }
+
+  LibUtilities::Timer timer;
+  bool doCheckTime = false;
+  int step = m_initialStep;
+  int stepCounter = 0;
+  int restartStep = -1;
+  NekDouble intTime = 0.0;
+  NekDouble cpuTime = 0.0;
+  NekDouble cpuPrevious = 0.0;
+  NekDouble elapsed = 0.0;
+  NekDouble totFilterTime = 0.0;
+
+  m_lastCheckTime = 0.0;
+
+  m_TotNewtonIts = 0;
+  m_TotLinIts = 0;
+  m_TotImpStages = 0;
+
+  Array<OneD, int> abortFlags(2, 0);
+  std::string abortFile = "abort";
+  if (m_session->DefinesSolverInfo("CheckAbortFile")) {
+    abortFile = m_session->GetSolverInfo("CheckAbortFile");
+  }
+
+  NekDouble tmp_cflSafetyFactor = m_cflSafetyFactor;
+
+  m_timestepMax = m_timestep;
+  while ((step < m_steps || m_time < m_fintime - NekConstants::kNekZeroTol) &&
+         abortFlags[1] == 0) {
+    restartStep++;
+
+    if (m_CFLGrowth > 1.0 && m_cflSafetyFactor < m_CFLEnd) {
+      tmp_cflSafetyFactor =
+          std::min(m_CFLEnd, m_CFLGrowth * tmp_cflSafetyFactor);
+    }
+
+    m_flagUpdatePreconMat = true;
+
+    // Flag to update AV
+    m_CalcPhysicalAV = true;
+    // Frozen preconditioner checks
+    if (UpdateTimeStepCheck()) {
+      m_cflSafetyFactor = tmp_cflSafetyFactor;
+
+      if (m_cflSafetyFactor) {
+        m_timestep = GetTimeStep(fields);
+      }
+
+      // Ensure that the final timestep finishes at the final
+      // time, or at a prescribed IO_CheckTime.
+      if (m_time + m_timestep > m_fintime && m_fintime > 0.0) {
+        m_timestep = m_fintime - m_time;
+      } else if (m_checktime &&
+                 m_time + m_timestep - m_lastCheckTime >= m_checktime) {
+        m_lastCheckTime += m_checktime;
+        m_timestep = m_lastCheckTime - m_time;
+        doCheckTime = true;
+      }
+    }
+
+    if (m_TimeIncrementFactor > 1.0) {
+      NekDouble timeincrementFactor = m_TimeIncrementFactor;
+      m_timestep *= timeincrementFactor;
+
+      if (m_time + m_timestep > m_fintime && m_fintime > 0.0) {
+        m_timestep = m_fintime - m_time;
+      }
+    }
+
+    // Perform any solver-specific pre-integration steps
+    timer.Start();
+    if (v_PreIntegrate(step)) {
+      break;
+    }
+
+    m_StagesPerStep = 0;
+    m_TotLinItePerStep = 0;
+
+    ASSERTL0(m_timestep > 0, "m_timestep < 0");
+
+    fields = m_intScheme->TimeIntegrate(stepCounter, m_timestep, m_ode);
+    timer.Stop();
+
+    m_time += m_timestep;
+    elapsed = timer.TimePerTest(1);
+    intTime += elapsed;
+    cpuTime += elapsed;
+
+    // Write out status information
+    if (m_session->GetComm()->GetRank() == 0 && !((step + 1) % m_infosteps)) {
+      std::cout << "Steps: " << std::setw(8) << std::left << step + 1 << " "
+                << "Time: " << std::setw(12) << std::left << m_time;
+
+      if (m_cflSafetyFactor) {
+        std::cout << " Time-step: " << std::setw(12) << std::left << m_timestep;
+      }
+
+      std::stringstream ss;
+      ss << cpuTime << "s";
+      std::cout << " CPU Time: " << std::setw(8) << std::left << ss.str()
+                << std::endl;
+      cpuPrevious = cpuTime;
+      cpuTime = 0.0;
+
+      if (m_flagImplicitItsStatistics && m_flagImplicitSolver) {
+        std::cout << "       &&"
+                  << " TotImpStages= " << m_TotImpStages
+                  << " TotNewtonIts= " << m_TotNewtonIts
+                  << " TotLinearIts = " << m_TotLinIts << std::endl;
+      }
+    }
+
+    // Transform data into coefficient space
+    for (i = 0; i < nvariables; ++i) {
+      // copy fields into ExpList::m_phys and assign the new
+      // array to fields
+      m_fields[m_intVariables[i]]->SetPhys(fields[i]);
+      fields[i] = m_fields[m_intVariables[i]]->UpdatePhys();
+      if (v_RequireFwdTrans()) {
+        m_fields[m_intVariables[i]]->FwdTransLocalElmt(
+            fields[i], m_fields[m_intVariables[i]]->UpdateCoeffs());
+      }
+      m_fields[m_intVariables[i]]->SetPhysState(false);
+    }
+
+    // Perform any solver-specific post-integration steps
+    if (v_PostIntegrate(step)) {
+      break;
+    }
+
+    // // Check for steady-state
+    // if (m_steadyStateTol > 0.0 && (!((step + 1) % m_steadyStateSteps))) {
+    //   if (CheckSteadyState(step, intTime)) {
+    //     if (m_comm->GetRank() == 0) {
+    //       cout << "Reached Steady State to tolerance " << m_steadyStateTol
+    //            << endl;
+    //     }
+    //     break;
+    //   }
+    // }
+
+    // test for abort conditions (nan, or abort file)
+    if (m_abortSteps && !((step + 1) % m_abortSteps)) {
+      abortFlags[0] = 0;
+      for (i = 0; i < nvariables; ++i) {
+        if (Vmath::Nnan(fields[i].size(), fields[i], 1) > 0) {
+          abortFlags[0] = 1;
+        }
+      }
+
+      // rank zero looks for abort file and deltes it
+      // if it exists. The communicates the abort
+      if (m_session->GetComm()->GetRank() == 0) {
+        if (boost::filesystem::exists(abortFile)) {
+          boost::filesystem::remove(abortFile);
+          abortFlags[1] = 1;
+        }
+      }
+
+      m_session->GetComm()->AllReduce(abortFlags, LibUtilities::ReduceMax);
+
+      ASSERTL0(!abortFlags[0], "NaN found during time integration.");
+    }
+
+    // Update filters
+    for (auto &x : m_filters) {
+      timer.Start();
+      x.second->Update(m_fields, m_time);
+      timer.Stop();
+      elapsed = timer.TimePerTest(1);
+      totFilterTime += elapsed;
+
+      // Write out individual filter status information
+      if (m_session->GetComm()->GetRank() == 0 &&
+          !((step + 1) % m_filtersInfosteps) && !m_filters.empty() &&
+          m_session->DefinesCmdLineArgument("verbose")) {
+        std::stringstream s0;
+        s0 << x.first << ":";
+        std::stringstream s1;
+        s1 << elapsed << "s";
+        std::stringstream s2;
+        s2 << elapsed / cpuPrevious * 100 << "%";
+        std::cout << "CPU time for filter " << std::setw(25) << std::left
+                  << s0.str() << std::setw(12) << std::left << s1.str()
+                  << std::endl
+                  << "\t Percentage of time integration:     " << std::setw(10)
+                  << std::left << s2.str() << std::endl;
+      }
+    }
+
+    // Write out overall filter status information
+    if (m_session->GetComm()->GetRank() == 0 &&
+        !((step + 1) % m_filtersInfosteps) && !m_filters.empty()) {
+      std::stringstream ss;
+      ss << totFilterTime << "s";
+      std::cout << "Total filters CPU Time:\t\t\t     " << std::setw(10)
+                << std::left << ss.str() << std::endl;
+    }
+    totFilterTime = 0.0;
+
+    // Write out checkpoint files
+    if ((m_checksteps && !((step + 1) % m_checksteps)) || doCheckTime) {
+      if (m_HomogeneousType != eNotHomogeneous) {
+        std::vector<bool> transformed(nfields, false);
+        for (i = 0; i < nfields; i++) {
+          if (m_fields[i]->GetWaveSpace()) {
+            m_fields[i]->SetWaveSpace(false);
+            m_fields[i]->BwdTrans(m_fields[i]->GetCoeffs(),
+                                  m_fields[i]->UpdatePhys());
+            m_fields[i]->SetPhysState(true);
+            transformed[i] = true;
+          }
+        }
+        Checkpoint_Output(m_nchk);
+        m_nchk++;
+        for (i = 0; i < nfields; i++) {
+          if (transformed[i]) {
+            m_fields[i]->SetWaveSpace(true);
+            m_fields[i]->HomogeneousFwdTrans(m_fields[i]->GetPhys(),
+                                             m_fields[i]->UpdatePhys());
+            m_fields[i]->SetPhysState(false);
+          }
+        }
+      } else {
+        Checkpoint_Output(m_nchk);
+        m_nchk++;
+      }
+      doCheckTime = false;
+    }
+
+    // Step advance
+    ++step;
+    ++stepCounter;
+  }
+
+  // Print out summary statistics
+  if (m_session->GetComm()->GetRank() == 0) {
+    if (m_cflSafetyFactor > 0.0) {
+      std::cout << "CFL safety factor : " << m_cflSafetyFactor << std::endl
+                << "CFL time-step     : " << m_timestep << std::endl;
+    }
+
+    if (m_session->GetSolverInfo("Driver") != "SteadyState") {
+      std::cout << "Time-integration  : " << intTime << "s" << std::endl;
+    }
+
+    if (m_flagImplicitItsStatistics && m_flagImplicitSolver) {
+      std::cout << "-------------------------------------------" << std::endl
+                << "Total Implicit Stages: " << m_TotImpStages << std::endl
+                << "Total Newton Its     : " << m_TotNewtonIts << std::endl
+                << "Total Linear Its     : " << m_TotLinIts << std::endl
+                << "-------------------------------------------" << std::endl;
+    }
+  }
+
+  // If homogeneous, transform back into physical space if necessary.
+  if (m_HomogeneousType != eNotHomogeneous) {
+    for (i = 0; i < nfields; i++) {
+      if (m_fields[i]->GetWaveSpace()) {
+        m_fields[i]->SetWaveSpace(false);
+        m_fields[i]->BwdTrans(m_fields[i]->GetCoeffs(),
+                              m_fields[i]->UpdatePhys());
+        m_fields[i]->SetPhysState(true);
+      }
+    }
+  } else {
+    for (i = 0; i < nvariables; ++i) {
+      m_fields[m_intVariables[i]]->SetPhys(fields[i]);
+      m_fields[m_intVariables[i]]->SetPhysState(true);
+    }
+  }
+
+  // Finalise filters
+  for (auto &x : m_filters) {
+    x.second->Finalise(m_fields, m_time);
+  }
+
+  // Print for 1D problems
+  if (m_spacedim == 1) {
+    v_AppendOutput1D(fields);
   }
 }
 

--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.h
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.h
@@ -114,6 +114,13 @@ protected:
   virtual void
   DoOdeRhs(const Array<OneD, const Array<OneD, NekDouble>> &inarray,
            Array<OneD, Array<OneD, NekDouble>> &outarray, const NekDouble time);
+
+  /**
+   * Override and substantially reimplement UnsteadySystem::v_DoSolve in order
+   * to get at (copied) field objects inside the timestep loop
+   */
+  virtual void v_DoSolve() override;
+
   void DoOdeProjection(const Array<OneD, const Array<OneD, NekDouble>> &inarray,
                        Array<OneD, Array<OneD, NekDouble>> &outarray,
                        const NekDouble time);

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -62,17 +62,17 @@ void SOLWithParticlesSystem::v_InitObject(bool DeclareField) {
   m_part_timestep = m_timestep / m_num_part_substeps;
 
   // Store DisContFieldSharedPtr casts of *_src fields in a map, indexed by
-  // name, to simplify projection of particle quantities later
+  // name, for use in particle project,evaluate operations
   int idx = 0;
   for (auto &field_name : m_session->GetVariables()) {
-    m_src_fields[field_name] =
+    m_discont_fields[field_name] =
         std::dynamic_pointer_cast<MultiRegions::DisContField>(m_fields[idx]);
     idx++;
   }
 
-  m_particle_sys->setup_project(m_src_fields["rho_src"]);
-  m_particle_sys->setup_evaluate_rho(m_src_fields["rho"]);
-  m_particle_sys->setup_evaluate_E(m_src_fields["E"]);
+  m_particle_sys->setup_project(m_discont_fields["rho_src"]);
+  m_particle_sys->setup_evaluate_rho(m_discont_fields["rho"]);
+  m_particle_sys->setup_evaluate_E(m_discont_fields["E"]);
 
   // Use an augmented version of SOLSystem's DefineOdeRhs()
   m_ode.DefineOdeRhs(&SOLWithParticlesSystem::DoOdeRhs, this);
@@ -104,7 +104,7 @@ void SOLWithParticlesSystem::DoOdeRhs(
   SOLSystem::DoOdeRhs(inarray, outarray, time);
 
   // // Zero the source term fields here?
-  // for (auto name_field_pair : this->m_src_fields) {
+  // for (auto name_field_pair : this->m_discont_fields) {
   //   Vmath::Zero(name_field_pair.second->GetTotPoints(),
   //               name_field_pair.second->UpdatePhys(), 1);
   // }

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -94,7 +94,7 @@ void SOLWithParticlesSystem::DoOdeRhs(
   m_particle_sys->integrate(time, m_part_timestep);
   // Project onto the source fields
   m_particle_sys->project_source_terms();
-  // m_particle_sys->write_source_fields();
+  m_particle_sys->write_source_fields();
 
   // Energy source field already calculated by the particle system? If not, do
   // so here

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.h
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.h
@@ -81,7 +81,7 @@ protected:
 
   // Source fields cast to DisContFieldSharedPtr, indexed by name, for use in
   // particle projection methods
-  std::map<std::string, MultiRegions::DisContFieldSharedPtr> m_src_fields;
+  std::map<std::string, MultiRegions::DisContFieldSharedPtr> m_discont_fields;
 
   virtual void
   DoOdeRhs(const Array<OneD, const Array<OneD, NekDouble>> &inarray,

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.h
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.h
@@ -83,13 +83,9 @@ protected:
   // particle projection methods
   std::map<std::string, MultiRegions::DisContFieldSharedPtr> m_discont_fields;
 
-  virtual void
-  DoOdeRhs(const Array<OneD, const Array<OneD, NekDouble>> &inarray,
-           Array<OneD, Array<OneD, NekDouble>> &outarray,
-           const NekDouble time) override;
-
   virtual void v_InitObject(bool DeclareField) override;
   virtual bool v_PostIntegrate(int step) override;
+  virtual bool v_PreIntegrate(int step) override;
 };
 
 } // namespace Nektar

--- a/solvers/SimpleSOL/Forcing/SourceTerms.cpp
+++ b/solvers/SimpleSOL/Forcing/SourceTerms.cpp
@@ -113,6 +113,20 @@ void SourceTerms::v_Apply(
   for (int i = 0; i < outarray[E_idx].size(); ++i) {
     outarray[E_idx][i] += CalcGaussian(m_E_prefac, m_mu, m_sigma, m_x[i]) / 2.0;
   }
+
+  // Add sources stored as separate fields, if they exist
+  std::vector<std::string> target_fields = {"rho", "rhou", "rhov", "E"};
+  for (auto target_field : target_fields) {
+    int src_field_idx = this->field_to_index.get_idx(target_field + "_src");
+    if (src_field_idx >= 0) {
+      int dst_field_idx = this->field_to_index.get_idx(target_field);
+      if (dst_field_idx >= 0) {
+        for (int i = 0; i < outarray[dst_field_idx].size(); ++i) {
+          outarray[dst_field_idx][i] += inarray[src_field_idx][i];
+        }
+      }
+    }
+  }
 }
 
 } // namespace Nektar


### PR DESCRIPTION
Attempts to resolve an issue with modifying fluid fields inside the timestep loop.

*Previous implementation*
- UnsteadySystem::m_fields is copied to a local variable, 'fields' in UnsteadySystem::v_DoSolve(). The timestepping operates on the copy, only pushing  the values to m_fields at the end of each step.
- So changes made to m_fields directly can never propagate to the timestep loop and will always be overwritten by the contents of the (local) fields array at the end of each timestep
- The only way to make changes that persist is by modifying 'outarray' inside v_DoOdeRhs which is a non-const ref to the RHS array for the current *stage* of the time-integrator
- For projection, v_DoOdeRhs works fine because we can project onto a temporary field and add the values to outarray, but for evaluation, we're forced to use m_fields, which still holds the values from the start of the timestep, not the current stage.

*New implementation*
1. Overrides UnsteadySystem::v_DoSolve(), copying the contents almost verbatim, but making 'fields' a non-const ref to m_fields
2. Moves particle updates from to SOLWithParticlesSystem::v_DoOdeRhs to SOLWithParticlesSystem::v_PreIntegrate

2\. isn't required to make things work, but to me, it makes more sense than doing particle updates at every stage of the (RK4) fluid integration.



