### PR TITLE
Project particle momentum and energy

### DIFF
--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -46,6 +46,7 @@
             <V ID="5"> rho_src </V>
             <V ID="6"> rhou_src </V>
             <V ID="7"> rhov_src </V>
+            <V ID="8"> E_src </V>
         </VARIABLES>
         <BOUNDARYREGIONS>
             <!-- Left edge-->
@@ -67,6 +68,7 @@
                 <N VAR="rho_src" VALUE="0" />
                 <N VAR="rhou_src" VALUE="0" />
                 <N VAR="rhov_src" VALUE="0" />
+                <N VAR="E_src" VALUE="0" />
             </REGION>
             <REGION REF="1">
                 <D VAR="rho" VALUE="rhoInf" />
@@ -77,6 +79,7 @@
                 <N VAR="rho_src" VALUE="0" />
                 <N VAR="rhou_src" VALUE="0" />
                 <N VAR="rhov_src" VALUE="0" />
+                <N VAR="E_src" VALUE="0" />
             </REGION>
             <REGION REF="2">
                 <P VAR="rho" VALUE="[3]" />
@@ -87,6 +90,7 @@
                 <P VAR="rho_src" VALUE="[3]" />
                 <P VAR="rhou_src" VALUE="[3]" />
                 <P VAR="rhov_src" VALUE="[3]" />
+                <P VAR="E_src" VALUE="[3]" />
             </REGION>
             <REGION REF="3">
                 <P VAR="rho" VALUE="[2]" />
@@ -97,11 +101,12 @@
                 <P VAR="rho_src" VALUE="[2]" />
                 <P VAR="rhou_src" VALUE="[2]" />
                 <P VAR="rhov_src" VALUE="[2]" />
+                <P VAR="E_src" VALUE="[2]" />
             </REGION>
         </BOUNDARYCONDITIONS>
         <FUNCTION NAME="InitialConditions">
           <F VAR="rho,rhou,rhov,E" FILE="ICs.rst" />
-          <E VAR="T,rho_src,rhou_src,rhov_src" DOMAIN="0" VALUE="0.0" />
+          <E VAR="T,rho_src,rhou_src,rhov_src,E_src" DOMAIN="0" VALUE="0.0" />
         </FUNCTION>
     </CONDITIONS>
 

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -44,6 +44,8 @@
             <V ID="3"> E </V>
             <V ID="4"> T </V>
             <V ID="5"> rho_src </V>
+            <V ID="6"> rhou_src </V>
+            <V ID="7"> rhov_src </V>
         </VARIABLES>
         <BOUNDARYREGIONS>
             <!-- Left edge-->
@@ -63,6 +65,8 @@
                 <D VAR="E" VALUE="pInf/(Gamma-1)+0.5*rhoInf*(uInf*uInf)" />
                 <N VAR="T" VALUE="0" />
                 <N VAR="rho_src" VALUE="0" />
+                <N VAR="rhou_src" VALUE="0" />
+                <N VAR="rhov_src" VALUE="0" />
             </REGION>
             <REGION REF="1">
                 <D VAR="rho" VALUE="rhoInf" />
@@ -71,6 +75,8 @@
                 <D VAR="E" VALUE="pInf/(Gamma-1)+0.5*rhoInf*(uInf*uInf)" />
                 <N VAR="T" VALUE="0" />
                 <N VAR="rho_src" VALUE="0" />
+                <N VAR="rhou_src" VALUE="0" />
+                <N VAR="rhov_src" VALUE="0" />
             </REGION>
             <REGION REF="2">
                 <P VAR="rho" VALUE="[3]" />
@@ -79,6 +85,8 @@
                 <P VAR="E" VALUE="[3]" />
                 <P VAR="T" VALUE="[3]" />
                 <P VAR="rho_src" VALUE="[3]" />
+                <P VAR="rhou_src" VALUE="[3]" />
+                <P VAR="rhov_src" VALUE="[3]" />
             </REGION>
             <REGION REF="3">
                 <P VAR="rho" VALUE="[2]" />
@@ -87,11 +95,13 @@
                 <P VAR="E" VALUE="[2]" />
                 <P VAR="T" VALUE="[2]" />
                 <P VAR="rho_src" VALUE="[2]" />
+                <P VAR="rhou_src" VALUE="[2]" />
+                <P VAR="rhov_src" VALUE="[2]" />
             </REGION>
         </BOUNDARYCONDITIONS>
         <FUNCTION NAME="InitialConditions">
           <F VAR="rho,rhou,rhov,E" FILE="ICs.rst" />
-          <E VAR="T,rho_src" DOMAIN="0" VALUE="0.0" />
+          <E VAR="T,rho_src,rhou_src,rhov_src" DOMAIN="0" VALUE="0.0" />
         </FUNCTION>
     </CONDITIONS>
 

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
@@ -812,6 +812,6 @@
         </Provenance>
     </Metadata>
     <EXPANSIONS>
-        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src" TYPE="MODIFIED" />
+        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src,E_src" TYPE="MODIFIED" />
     </EXPANSIONS>
 </NEKTAR>

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
@@ -812,6 +812,6 @@
         </Provenance>
     </Metadata>
     <EXPANSIONS>
-        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src" TYPE="MODIFIED" />
+        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src" TYPE="MODIFIED" />
     </EXPANSIONS>
 </NEKTAR>

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -50,6 +50,8 @@ SOLWithParticlesSystem::SOLWithParticlesSystem(
 
   m_particle_sys = std::make_shared<NeutralParticleSystem>(pSession, pGraph);
   m_required_flds.push_back("rho_src");
+  m_required_flds.push_back("rhou_src");
+  m_required_flds.push_back("rhov_src");
   m_required_flds.push_back("T");
 }
 

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -88,7 +88,9 @@ void SOLWithParticlesSystem::v_InitObject(bool DeclareField) {
     idx++;
   }
 
-  m_particle_sys->setup_project(m_discont_fields["rho_src"]);
+  m_particle_sys->setup_project(m_discont_fields["rho_src"],
+                                m_discont_fields["rhou_src"],
+                                m_discont_fields["rhov_src"]);
   m_particle_sys->setup_evaluate_rho(m_discont_fields["rho"]);
   m_particle_sys->setup_evaluate_T(m_discont_fields["T"]);
 

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -49,6 +49,7 @@ SOLWithParticlesSystem::SOLWithParticlesSystem(
       SOLSystem(pSession, pGraph), field_to_index(pSession->GetVariables()) {
 
   m_particle_sys = std::make_shared<NeutralParticleSystem>(pSession, pGraph);
+  m_required_flds.push_back("E_src");
   m_required_flds.push_back("rho_src");
   m_required_flds.push_back("rhou_src");
   m_required_flds.push_back("rhov_src");

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -89,9 +89,10 @@ void SOLWithParticlesSystem::v_InitObject(bool DeclareField) {
     idx++;
   }
 
-  m_particle_sys->setup_project(m_discont_fields["rho_src"],
-                                m_discont_fields["rhou_src"],
-                                m_discont_fields["rhov_src"]);
+  m_particle_sys->setup_project(
+      m_discont_fields["rho_src"], m_discont_fields["rhou_src"],
+      m_discont_fields["rhov_src"], m_discont_fields["E_src"]);
+
   m_particle_sys->setup_evaluate_rho(m_discont_fields["rho"]);
   m_particle_sys->setup_evaluate_T(m_discont_fields["T"]);
 

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -734,7 +734,7 @@ public:
                 k_SM[cellx][1][layerx] =
                     k_SD[cellx][0][layerx] * v_s * k_sin_theta;
                 // Set value for fluid energy source
-                k_SE[cellx][1][layerx] = k_SD[cellx][0][layerx] * v_s * v_s / 2;
+                k_SE[cellx][0][layerx] = k_SD[cellx][0][layerx] * v_s * v_s / 2;
                 NESO_PARTICLES_KERNEL_END
               });
         })

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -92,7 +92,7 @@ protected:
   std::shared_ptr<FieldEvaluate<DisContField>> field_evaluate_T;
 
   int debug_write_fields_count;
-  std::shared_ptr<DisContField> debug_write_field;
+  std::map<std::string, std::shared_ptr<DisContField>> debug_write_fields;
 
 public:
   /// Disable (implicit) copies.
@@ -181,7 +181,7 @@ public:
         ParticleProp(Sym<INT>("PARTICLE_ID"), 2),
         ParticleProp(Sym<REAL>("COMPUTATIONAL_WEIGHT"), 1),
         ParticleProp(Sym<REAL>("SOURCE_DENSITY"), 1),
-        ParticleProp(Sym<REAL>("SOURCE_MOMENTUM"), 1),
+        ParticleProp(Sym<REAL>("SOURCE_MOMENTUM"), 2),
         ParticleProp(Sym<REAL>("ELECTRON_DENSITY"), 1),
         ParticleProp(Sym<REAL>("ELECTRON_TEMPERATURE"), 1),
         ParticleProp(Sym<REAL>("MASS"), 1),
@@ -309,13 +309,20 @@ public:
   /**
    * Setup the projection object to use the following fields.
    *
-   * @param rho_src Nektar++ field to project ionised particle data onto.
+   * @param rho_src Nektar++ fields to project ionised particle data onto.
    */
-  inline void setup_project(std::shared_ptr<DisContField> rho_src) {
-    std::vector<std::shared_ptr<DisContField>> fields = {rho_src};
+  inline void setup_project(std::shared_ptr<DisContField> rho_src,
+                            std::shared_ptr<DisContField> rhou_src,
+                            std::shared_ptr<DisContField> rhov_src) {
+    std::vector<std::shared_ptr<DisContField>> fields = {rho_src, rhou_src,
+                                                         rhov_src};
     this->field_project = std::make_shared<FieldProject<DisContField>>(
         fields, this->particle_group, this->cell_id_translation);
-    this->debug_write_field = rho_src;
+
+    // Setup debugging output for each field
+    this->debug_write_fields["rho_src"] = rho_src;
+    this->debug_write_fields["rhou_src"] = rhou_src;
+    this->debug_write_fields["rhov_src"] = rhov_src;
   }
 
   /**
@@ -346,8 +353,10 @@ public:
     NESOASSERT(this->field_project != nullptr,
                "Field project object is null. Was setup_project called?");
 
-    std::vector<Sym<REAL>> syms = {Sym<REAL>("SOURCE_DENSITY")};
-    std::vector<int> components = {0};
+    std::vector<Sym<REAL>> syms = {Sym<REAL>("SOURCE_DENSITY"),
+                                   Sym<REAL>("SOURCE_MOMENTUM"),
+                                   Sym<REAL>("SOURCE_MOMENTUM")};
+    std::vector<int> components = {0, 0, 1};
     this->field_project->project(syms, components);
   }
 
@@ -435,9 +444,12 @@ public:
    *  Write the projection fields to vtu for debugging.
    */
   inline void write_source_fields() {
-    std::string filename =
-        "debug_" + std::to_string(this->debug_write_fields_count++) + ".vtu";
-    write_vtu(this->debug_write_field, filename);
+    for (auto entry : this->debug_write_fields) {
+      std::string filename = "debug_" + entry.first + "_" +
+                             std::to_string(this->debug_write_fields_count++) +
+                             ".vtu";
+      write_vtu(entry.second, filename);
+    }
   }
 
   /**

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -726,7 +726,7 @@ public:
                 const REAL weight = k_W[cellx][0][layerx];
                 // note that the rate will be a positive number, so minus sign
                 // here
-                const REAL deltaweight = -rate * k_dt * rho;
+                REAL deltaweight = -rate * k_dt * rho;
                 /* Check whether weight is about to drop below zero
                    If so, flag particle for removal and adjust deltaweight
                 */

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -46,6 +46,7 @@
             <V ID="5"> rho_src </V>
             <V ID="6"> rhou_src </V>
             <V ID="7"> rhov_src </V>
+            <V ID="8"> E_src </V>
         </VARIABLES>
         <BOUNDARYREGIONS>
             <!-- Left edge-->
@@ -67,6 +68,7 @@
                 <N VAR="rho_src" VALUE="0" />
                 <N VAR="rhou_src" VALUE="0" />
                 <N VAR="rhov_src" VALUE="0" />
+                <N VAR="E_src" VALUE="0" />
             </REGION>
             <REGION REF="1">
                 <D VAR="rho" VALUE="rhoInf" />
@@ -77,6 +79,7 @@
                 <N VAR="rho_src" VALUE="0" />
                 <N VAR="rhou_src" VALUE="0" />
                 <N VAR="rhov_src" VALUE="0" />
+                <N VAR="E_src" VALUE="0" />
             </REGION>
             <REGION REF="2">
                 <P VAR="rho" VALUE="[3]" />
@@ -87,6 +90,7 @@
                 <P VAR="rho_src" VALUE="[3]" />
                 <P VAR="rhou_src" VALUE="[3]" />
                 <P VAR="rhov_src" VALUE="[3]" />
+                <P VAR="E_src" VALUE="[3]" />
             </REGION>
             <REGION REF="3">
                 <P VAR="rho" VALUE="[2]" />
@@ -97,11 +101,12 @@
                 <P VAR="rho_src" VALUE="[2]" />
                 <P VAR="rhou_src" VALUE="[2]" />
                 <P VAR="rhov_src" VALUE="[2]" />
+                <P VAR="E_src" VALUE="[2]" />
             </REGION>
         </BOUNDARYCONDITIONS>
         <FUNCTION NAME="InitialConditions">
           <F VAR="rho,rhou,rhov,E" FILE="ICs.rst" />
-          <E VAR="T,rho_src,rhou_src,rhov_src" DOMAIN="0" VALUE="0.0" />
+          <E VAR="T,rho_src,rhou_src,rhov_src,E_src" DOMAIN="0" VALUE="0.0" />
         </FUNCTION>
     </CONDITIONS>
 

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -44,6 +44,8 @@
             <V ID="3"> E </V>
             <V ID="4"> T </V>
             <V ID="5"> rho_src </V>
+            <V ID="6"> rhou_src </V>
+            <V ID="7"> rhov_src </V>
         </VARIABLES>
         <BOUNDARYREGIONS>
             <!-- Left edge-->
@@ -61,16 +63,20 @@
                 <D VAR="rhou" VALUE="-rhoInf*uInf" />
                 <D VAR="rhov" VALUE="0" />
                 <D VAR="E" VALUE="pInf/(Gamma-1)+0.5*rhoInf*(uInf*uInf)" />
-                <D VAR="T" VALUE="0" />
+                <N VAR="T" VALUE="0" />
                 <N VAR="rho_src" VALUE="0" />
+                <N VAR="rhou_src" VALUE="0" />
+                <N VAR="rhov_src" VALUE="0" />
             </REGION>
             <REGION REF="1">
                 <D VAR="rho" VALUE="rhoInf" />
                 <D VAR="rhou" VALUE="rhoInf*uInf" />
                 <D VAR="rhov" VALUE="0" />
                 <D VAR="E" VALUE="pInf/(Gamma-1)+0.5*rhoInf*(uInf*uInf)" />
-                <D VAR="T" VALUE="0" />
+                <N VAR="T" VALUE="0" />
                 <N VAR="rho_src" VALUE="0" />
+                <N VAR="rhou_src" VALUE="0" />
+                <N VAR="rhov_src" VALUE="0" />
             </REGION>
             <REGION REF="2">
                 <P VAR="rho" VALUE="[3]" />
@@ -79,6 +85,8 @@
                 <P VAR="E" VALUE="[3]" />
                 <P VAR="T" VALUE="[3]" />
                 <P VAR="rho_src" VALUE="[3]" />
+                <P VAR="rhou_src" VALUE="[3]" />
+                <P VAR="rhov_src" VALUE="[3]" />
             </REGION>
             <REGION REF="3">
                 <P VAR="rho" VALUE="[2]" />
@@ -87,11 +95,13 @@
                 <P VAR="E" VALUE="[2]" />
                 <P VAR="T" VALUE="[2]" />
                 <P VAR="rho_src" VALUE="[2]" />
+                <P VAR="rhou_src" VALUE="[2]" />
+                <P VAR="rhov_src" VALUE="[2]" />
             </REGION>
         </BOUNDARYCONDITIONS>
         <FUNCTION NAME="InitialConditions">
           <F VAR="rho,rhou,rhov,E" FILE="ICs.rst" />
-          <E VAR="T,rho_src" DOMAIN="0" VALUE="0.0" />
+          <E VAR="T,rho_src,rhou_src,rhov_src" DOMAIN="0" VALUE="0.0" />
         </FUNCTION>
     </CONDITIONS>
 

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
@@ -812,6 +812,6 @@
         </Provenance>
     </Metadata>
     <EXPANSIONS>
-        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src" TYPE="MODIFIED" />
+        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src,E_src" TYPE="MODIFIED" />
     </EXPANSIONS>
 </NEKTAR>

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_mesh.xml
@@ -812,6 +812,6 @@
         </Provenance>
     </Metadata>
     <EXPANSIONS>
-        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src" TYPE="MODIFIED" />
+        <E COMPOSITE="C[0]" NUMMODES="5" FIELDS="rho,rhou,rhov,E,T,rho_src,rhou_src,rhov_src" TYPE="MODIFIED" />
     </EXPANSIONS>
 </NEKTAR>


### PR DESCRIPTION
# Description

- Adds rhou_src, rhov_src, E_src fluid fields
- Makes SOURCE_MOMENTUM particle prop a 2-element vector
- Adds a SOURCE_ENERGY particle prop
- Populates particle properties for source energy and momentum (along SimpleSOL problem axis) in ionisation kernel
- Projects SOURCE_MOMENTUM[0],SOURCE_MOMENTUM[1], SOURCE_ENERGY onto rhou_src, rhov_src, E_src respectively

N.B. New source fields automatically added to Nektar-integrated fields by SourceTerms::v_Apply()

Fixes #156

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Passes existing (placeholder) SimpleSOLTest.2DWithParticles integration test for both toolsets.

**Test Configuration**:

OS: Ubuntu 22.04
Compiler: GCC 11.3.0 / OneAPI v2022.1.0
SYCL implementation: Hipsycl v0.9.2 / DPC++ v2022.1.0
MPI details: MPICH v4.0.2
Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have used understandable variable names
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
```

