### PR TITLE
Unit conversion for ionisation calculation

### DIFF
--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -20,7 +20,7 @@
             <P> num_particles_per_cell = -1 </P>
             <P> particle_num_write_particle_steps = 4 </P>
             <P> particle_thermal_velocity = 1.0 </P>
-            <P> particle_number_density = 105.27578027828649 </P>
+            <P> particle_number_density = 3e18 </P>
             <P> particle_source_region_count = 2 </P>
             <P> particle_source_region_offset = 0.01 </P>
             <P> particle_source_region_gaussian_width = 0.000001 </P>

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -23,7 +23,7 @@
             <P> particle_number_density = 3e18 </P>
             <P> particle_source_region_count = 2 </P>
             <P> particle_source_region_offset = 0.01 </P>
-            <P> particle_source_region_gaussian_width = 0.000001 </P>
+            <P> particle_source_region_gaussian_width = 0.0001 </P>
             <P> particle_source_lines_per_gaussian = 7 </P>
             <P> unrotated_x_max = 110.0 </P>
             <P> unrotated_y_max = 1.0 </P>

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -93,7 +93,7 @@ void SOLWithParticlesSystem::v_InitObject(bool DeclareField) {
       m_discont_fields["rho_src"], m_discont_fields["rhou_src"],
       m_discont_fields["rhov_src"], m_discont_fields["E_src"]);
 
-  m_particle_sys->setup_evaluate_rho(m_discont_fields["rho"]);
+  m_particle_sys->setup_evaluate_n(m_discont_fields["rho"]);
   m_particle_sys->setup_evaluate_T(m_discont_fields["T"]);
 
   // Use customised version of DoOdeRhs that updates temperature field

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -802,7 +802,7 @@ public:
                 // get the temperatue in eV. TODO: ensure not unit conversion is
                 // required
                 const REAL TeV = k_TeV[cellx][0][layerx];
-                const REAL n = k_n[cellx][0][layerx];
+                const REAL n_SI = k_n[cellx][0][layerx];
                 const REAL invratio = k_E_i / TeV;
                 const REAL rate = -k_rate_factor / (TeV * std::sqrt(TeV)) *
                                   (expint_barry_approx(invratio) / invratio +
@@ -811,7 +811,7 @@ public:
                 const REAL weight = k_W[cellx][0][layerx];
                 // note that the rate will be a positive number, so minus sign
                 // here
-                REAL deltaweight = -rate * k_dt_SI * n;
+                REAL deltaweight = -rate * k_dt_SI * n_SI;
                 /* Check whether weight is about to drop below zero
                    If so, flag particle for removal and adjust deltaweight
                 */

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -270,18 +270,20 @@ public:
     get_from_session(this->session, "unrotated_y_max", this->unrotated_y_max,
                      1.0);
 
-    const double volume =
-        std::pow(L_to_SI, 3) * this->unrotated_x_max * this->unrotated_y_max;
+    const double particle_region_volume =
+        particle_source_region_gaussian_width * std::pow(L_to_SI, 3) *
+        this->unrotated_x_max * this->unrotated_y_max;
 
     // read or deduce a number density from the configuration file
     this->session->LoadParameter("particle_number_density",
                                  this->particle_number_density);
     if (this->particle_number_density < 0.0) {
       this->particle_weight = 1.0;
-      this->particle_number_density = this->num_particles / volume;
+      this->particle_number_density =
+          this->num_particles / particle_region_volume;
     } else {
       const double number_physical_particles =
-          this->particle_number_density * volume;
+          this->particle_number_density * particle_region_volume;
       this->particle_weight = number_physical_particles / this->num_particles;
     }
 

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -135,10 +135,9 @@ public:
   std::shared_ptr<H5Part> h5part;
 
   // Factors to convert nektar units to units required by ionisation calc
-  double n_to_SI;
   double t_to_SI;
   double T_to_eV;
-  double vel_to_SI;
+  double n_to_SI;
 
   /**
    *  Create a new instance.
@@ -212,13 +211,13 @@ public:
 
     // SI scaling factors
     const double Rs_to_SI = Rs_SI / Rs;
-    this->vel_to_SI = SOL_sound_speed_SI / uInf;
-    const double T_to_K = this->vel_to_SI * this->vel_to_SI / Rs_to_SI;
+    const double vel_to_SI = SOL_sound_speed_SI / uInf;
+    const double T_to_K = vel_to_SI * vel_to_SI / Rs_to_SI;
     // Scaling factors for units required by ionise()
     this->n_to_SI = SOL_num_density_SI / rhoInf;
     this->T_to_eV = T_to_K * kB_eV_per_K;
     double V_to_SI = 1 / this->n_to_SI;
-    this->t_to_SI = std::pow(V_to_SI, 1. / 3.) / this->vel_to_SI;
+    this->t_to_SI = std::pow(V_to_SI, 1. / 3.) / vel_to_SI;
 
     // Create ParticleGroup
     ParticleSpec particle_spec{
@@ -743,7 +742,6 @@ public:
     this->evaluate_fields();
 
     const double k_dt = dt * this->t_to_SI;
-    const double k_vel_to_nektar = 1 / this->vel_to_SI;
 
     const double k_a_i = 4.0e-14; // a_i constant for hydrogen (a_1)
     const double k_b_i = 0.6;     // b_i constant for hydrogen (b_1)
@@ -825,9 +823,8 @@ public:
 
                 // Compute velocity along the SimpleSOL problem axis.
                 // (No momentum coupling in orthogonal dimensions)
-                const REAL v_s = (k_V[cellx][0][layerx] * k_cos_theta +
-                                  k_V[cellx][1][layerx] * k_sin_theta) *
-                                 k_vel_to_nektar;
+                const REAL v_s = k_V[cellx][0][layerx] * k_cos_theta +
+                                 k_V[cellx][1][layerx] * k_sin_theta;
                 // Set value for fluid momentum density source
                 k_SM[cellx][0][layerx] =
                     k_SD[cellx][0][layerx] * v_s * k_cos_theta;

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -743,7 +743,8 @@ public:
     // Evaluate the density and temperature fields at the particle locations
     this->evaluate_fields();
 
-    const double k_dt = dt * this->t_to_SI;
+    const double k_dt = dt;
+    const double k_dt_SI = dt * this->t_to_SI;
 
     const double k_a_i = 4.0e-14; // a_i constant for hydrogen (a_1)
     const double k_b_i = 0.6;     // b_i constant for hydrogen (b_1)
@@ -810,7 +811,7 @@ public:
                 const REAL weight = k_W[cellx][0][layerx];
                 // note that the rate will be a positive number, so minus sign
                 // here
-                REAL deltaweight = -rate * k_dt * n;
+                REAL deltaweight = -rate * k_dt_SI * n;
                 /* Check whether weight is about to drop below zero
                    If so, flag particle for removal and adjust deltaweight
                 */
@@ -820,8 +821,8 @@ public:
                 }
                 // Mutate the weight on the particle
                 k_W[cellx][0][layerx] += deltaweight;
-                // Set value for fluid density source
-                k_SD[cellx][0][layerx] = -deltaweight;
+                // Set value for fluid density source (num / Nektar unit time)
+                k_SD[cellx][0][layerx] = -deltaweight / k_dt;
 
                 // Compute velocity along the SimpleSOL problem axis.
                 // (No momentum coupling in orthogonal dimensions)

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -747,6 +747,7 @@ public:
 
     const double k_dt = dt;
     const double k_dt_SI = dt * this->t_to_SI;
+    const double k_n_scale = 1 / this->n_to_SI;
 
     const double k_a_i = 4.0e-14; // a_i constant for hydrogen (a_1)
     const double k_b_i = 0.6;     // b_i constant for hydrogen (b_1)
@@ -824,7 +825,7 @@ public:
                 // Mutate the weight on the particle
                 k_W[cellx][0][layerx] += deltaweight;
                 // Set value for fluid density source (num / Nektar unit time)
-                k_SD[cellx][0][layerx] = -deltaweight / k_dt;
+                k_SD[cellx][0][layerx] = -deltaweight * k_n_scale / k_dt;
 
                 // Compute velocity along the SimpleSOL problem axis.
                 // (No momentum coupling in orthogonal dimensions)

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -213,11 +213,13 @@ public:
     const double Rs_to_SI = Rs_SI / Rs;
     const double vel_to_SI = SOL_sound_speed_SI / uInf;
     const double T_to_K = vel_to_SI * vel_to_SI / Rs_to_SI;
+
     // Scaling factors for units required by ionise()
     this->n_to_SI = SOL_num_density_SI / rhoInf;
     this->T_to_eV = T_to_K * kB_eV_per_K;
-    double V_to_SI = 1 / this->n_to_SI;
-    this->t_to_SI = std::pow(V_to_SI, 1. / 3.) / vel_to_SI;
+    // nektar length unit already in m
+    double L_to_SI = 1;
+    this->t_to_SI = L_to_SI / vel_to_SI;
 
     // Create ParticleGroup
     ParticleSpec particle_spec{
@@ -269,7 +271,7 @@ public:
                      1.0);
 
     const double volume =
-        V_to_SI * this->unrotated_x_max * this->unrotated_y_max;
+        std::pow(L_to_SI, 3) * this->unrotated_x_max * this->unrotated_y_max;
 
     // read or deduce a number density from the configuration file
     this->session->LoadParameter("particle_number_density",

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -135,9 +135,10 @@ public:
   std::shared_ptr<H5Part> h5part;
 
   // Factors to convert nektar units to units required by ionisation calc
+  double n_to_SI;
   double t_to_SI;
   double T_to_eV;
-  double n_to_SI;
+  double vel_to_SI;
 
   /**
    *  Create a new instance.
@@ -211,13 +212,13 @@ public:
 
     // SI scaling factors
     const double Rs_to_SI = Rs_SI / Rs;
-    const double vel_to_SI = SOL_sound_speed_SI / uInf;
-    const double T_to_K = vel_to_SI * vel_to_SI / Rs_to_SI;
+    this->vel_to_SI = SOL_sound_speed_SI / uInf;
+    const double T_to_K = this->vel_to_SI * this->vel_to_SI / Rs_to_SI;
     // Scaling factors for units required by ionise()
     this->n_to_SI = SOL_num_density_SI / rhoInf;
     this->T_to_eV = T_to_K * kB_eV_per_K;
     double V_to_SI = 1 / this->n_to_SI;
-    this->t_to_SI = std::pow(V_to_SI, 1. / 3.) / vel_to_SI;
+    this->t_to_SI = std::pow(V_to_SI, 1. / 3.) / this->vel_to_SI;
 
     // Create ParticleGroup
     ParticleSpec particle_spec{
@@ -742,6 +743,7 @@ public:
     this->evaluate_fields();
 
     const double k_dt = dt * this->t_to_SI;
+    const double k_vel_to_nektar = 1 / this->vel_to_SI;
 
     const double k_a_i = 4.0e-14; // a_i constant for hydrogen (a_1)
     const double k_b_i = 0.6;     // b_i constant for hydrogen (b_1)
@@ -823,8 +825,9 @@ public:
 
                 // Compute velocity along the SimpleSOL problem axis.
                 // (No momentum coupling in orthogonal dimensions)
-                const REAL v_s = k_V[cellx][0][layerx] * k_cos_theta +
-                                 k_V[cellx][1][layerx] * k_sin_theta;
+                const REAL v_s = (k_V[cellx][0][layerx] * k_cos_theta +
+                                  k_V[cellx][1][layerx] * k_sin_theta) *
+                                 k_vel_to_nektar;
                 // Set value for fluid momentum density source
                 k_SM[cellx][0][layerx] =
                     k_SD[cellx][0][layerx] * v_s * k_cos_theta;

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -813,7 +813,7 @@ public:
                 const REAL weight = k_W[cellx][0][layerx];
                 // note that the rate will be a positive number, so minus sign
                 // here
-                REAL deltaweight = -rate * k_dt_SI * n_SI;
+                REAL deltaweight = -rate * weight * k_dt_SI * n_SI;
                 /* Check whether weight is about to drop below zero
                    If so, flag particle for removal and adjust deltaweight
                 */

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -20,7 +20,7 @@
             <P> num_particles_per_cell = -1 </P>
             <P> particle_num_write_particle_steps = 4 </P>
             <P> particle_thermal_velocity = 1.0 </P>
-            <P> particle_number_density = 105.27578027828649 </P>
+            <P> particle_number_density = 3e18 </P>
             <P> particle_source_region_count = 2 </P>
             <P> particle_source_region_offset = 0.01 </P>
             <P> particle_source_region_gaussian_width = 0.000001 </P>

--- a/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/test/integration/solvers/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -23,7 +23,7 @@
             <P> particle_number_density = 3e18 </P>
             <P> particle_source_region_count = 2 </P>
             <P> particle_source_region_offset = 0.01 </P>
-            <P> particle_source_region_gaussian_width = 0.000001 </P>
+            <P> particle_source_region_gaussian_width = 0.0001 </P>
             <P> particle_source_lines_per_gaussian = 7 </P>
             <P> unrotated_x_max = 110.0 </P>
             <P> unrotated_y_max = 1.0 </P>


### PR DESCRIPTION
# Description

Convert Nektar units to SI for the ionisation calculation, then source terms back into Nektar units ready for projection.

Fixes #154 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Passes existing integration, unit tests

**Test Configuration**:

* OS: Ubuntu 22.04
* Compiler: GCC 11.3.0 / OneAPI v2022.1.0
* SYCL implementation: Hipsycl v0.9.2 / DPC++ v2022.1.0
* MPI details: MPICH v4.0.2
* Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have used understandable variable names
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
