### PR TITLE
fixed normalisation of potential evaluations in 2d3v elecpic

### DIFF
--- a/solvers/Electrostatic2D3V/ElectrostaticElectronBernsteinWaves2D3V.hpp
+++ b/solvers/Electrostatic2D3V/ElectrostaticElectronBernsteinWaves2D3V.hpp
@@ -200,7 +200,7 @@ public:
     if (this->line_field_deriv_evaluations_flag) {
       this->line_field_evaluations = std::make_shared<LineFieldEvaluations<T>>(
           this->poisson_particle_coupling->potential_function,
-          this->charged_particles, eval_nx, eval_ny);
+          this->charged_particles, eval_nx, eval_ny, false, true);
       this->line_field_deriv_evaluations =
           std::make_shared<LineFieldEvaluations<T>>(
               this->poisson_particle_coupling->potential_function,

--- a/solvers/Electrostatic2D3V/ElectrostaticTwoStream2D3V.hpp
+++ b/solvers/Electrostatic2D3V/ElectrostaticTwoStream2D3V.hpp
@@ -229,7 +229,7 @@ public:
     if (this->line_field_deriv_evaluations_flag) {
       this->line_field_evaluations = std::make_shared<LineFieldEvaluations<T>>(
           this->poisson_particle_coupling->potential_function,
-          this->charged_particles, eval_nx, eval_ny);
+          this->charged_particles, eval_nx, eval_ny, false, true);
       this->line_field_deriv_evaluations =
           std::make_shared<LineFieldEvaluations<T>>(
               this->poisson_particle_coupling->potential_function,


### PR DESCRIPTION
# Bugfix for electric potential field evaluation in 2D3V ElectrostaticPIC

Previous implementation did not compute or apply the constant offset that normalises the potential such that the integral over the domain is zero.
