### PR TITLE
Update test_mms.cpp to work on macOS

### DIFF
--- a/test/integration/test_mms.cpp
+++ b/test/integration/test_mms.cpp
@@ -75,7 +75,7 @@ TEST(MMSTest, TwoStreamGrowthRate) {
   // that the run finishes as the
   // instability saturates.
   Mesh mesh(128, 0.05, 40);
-  Species electrons(mesh, true, 2.0, 1, 1, 12800);
+  Species electrons(mesh, true, 2.0, 1, 1, 14600);
   Species ions(mesh, false, 2.0, -1, 1836);
   std::vector<Species> species_list;
   species_list.push_back(electrons);


### PR DESCRIPTION
# Description

Changes the number of electrons in the TwoStreamGrowthRate test, so that the test can pass in a direct build on MacOS.

Fixes # (issue)
Fixed issue with TwoStreamGrowthRate test not passing in MacOS.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change)

# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.

- Ran TwoStreamGrowthRate test and passed

**Test Configuration**:

* OS:MacOS
* SYCL implementation: 
* MPI details:
* Hardware:M1 Pro MacBook Pro

# Checklist:

- [] New and existing unit tests pass locally with my changes

######### DELETE THIS AND BELOW #########

# How-to:

1. Format C++ source code with clang-format

```
find ./src ./include ./test -iname \*.hpp -o -iname \*.cpp | xargs clang-format -i
```

2. Format cmake files with cmake-format

```
cmake-format -i CMakeLists.txt src/nektar/CMakeLists.txt test/CMakeLists.txt
```

3. Format python with black

```
find ./python -iname \*.py | xargs black
```

