### PR TITLE
Add CODEOWNER for actions as security measure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Owner of all files with .github to control actions
+.github/ @jwscook


### PR DESCRIPTION
# Description

This alerts me (others can be made CODEOWNERS of .github too) if a fork of NESO tries to run the actions.