### PR TITLE
Update neso.yaml with manual trigger

### DIFF
--- a/.github/disabled_workflows/neso.yaml
+++ b/.github/disabled_workflows/neso.yaml
@@ -1,5 +1,13 @@
 name: NESO
-on: [push]
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+    permissions:
+      teams:
+        - NESO-Admins
+
 jobs:
   build:
     name: OMP Build


### PR DESCRIPTION
In preparation of deploying to cloud ci, this causes the CI to run only with human intervention from someone in the NESO-Admins team

# Description

This PR is in preparation of using cloud CI where we want to limit the spend by not spamming the runner with every tiny push. This PR will cause the CI to trigger only when someone in the NESO-Admins team pushes the button.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.

- [ ] Test Foo in /test/path/to/file_for_test_Foo.cpp
 - Description of test Foo
- [ ] Test Bar in /test/path/to/file_for_test_Bar.cpp
 - Description of test Bar

**Test Configuration**:

* OS:
* SYCL implementation:
* MPI details:
* Hardware:

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new dependencies are automatically built for users via `cmake`
- [ ] I have used understandable variable names
- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [ ] I have run `black` against changes to `*.py`
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
