### PR TITLE
Feature/cmake globs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ENABLE_NESO_TESTS
 
 # Various sanitizers, including coverage and address sanitizer
 include(cmake/Sanitizers.cmake)
+include(cmake/CheckFileList.cmake)
 
 # ##############################################################################
 # Find dependencies
@@ -110,6 +111,10 @@ set(LIB_SRC_FILES
     ${SRC_DIR}/run_info.cpp
     ${SRC_DIR}/simulation.cpp
     ${SRC_DIR}/species.cpp)
+
+set(LIB_SRC_FILES_IGNORE ${SRC_DIR}/main.cpp)
+check_file_list(${SRC_DIR} cpp "${LIB_SRC_FILES}" "${LIB_SRC_FILES_IGNORE}")
+
 set(MAIN_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
 set(HEADER_FILES
     ${INC_DIR}/atomic_data_reader.hpp
@@ -189,6 +194,9 @@ set(HEADER_FILES
     ${INC_DIR}/simulation.hpp
     ${INC_DIR}/species.hpp
     ${INC_DIR}/velocity.hpp)
+
+set(HEADER_FILES_IGNORE ${INC_DIR}/revision.hpp)
+check_file_list(${INC_DIR} hpp "${HEADER_FILES}" "${HEADER_FILES_IGNORE}")
 
 # Create library
 set(NESO_LIBRARY_NAME nesolib)

--- a/cmake/CheckFileList.cmake
+++ b/cmake/CheckFileList.cmake
@@ -1,0 +1,19 @@
+# Function to compare files found using a recursive glob for an extension in a
+# directory against a given list. The ignore files parameter indicates files in
+# the directory which are not expected to be found by the glob.
+function(CHECK_FILE_LIST SRC_DIR EXT LISTED_FILES IGNORE_FILES)
+
+  file(GLOB_RECURSE FOUND_FILES ${SRC_DIR}/*.${EXT})
+  list(REMOVE_ITEM FOUND_FILES ${LISTED_FILES})
+  list(REMOVE_ITEM FOUND_FILES ${IGNORE_FILES})
+
+  list(LENGTH FOUND_FILES FOUND_FILES_LENGTH)
+  if (${FOUND_FILES_LENGTH})
+    message(WARNING "The following files are not included in a cmake list:")
+    foreach(FILEX ${FOUND_FILES})
+      message(${FILEX})
+    endforeach()
+    message(WARNING "End of list.")
+  endif()
+
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,9 +50,6 @@ set(UNIT_SRC_FILES
 
 check_file_list(${UNIT_SRC} cpp "${UNIT_SRC_FILES}" "")
 
-
-
-
 set(INTEGRATION_SRC ${CMAKE_CURRENT_SOURCE_DIR}/integration)
 set(INTEGRATION_SRC_FILES
     ${TEST_MAIN}
@@ -64,6 +61,8 @@ set(INTEGRATION_SRC_FILES
     ${INTEGRATION_SRC}/solvers/Electrostatic2D3V/ElectronBernsteinWaves/test_ebw.cpp
     ${INTEGRATION_SRC}/solvers/Electrostatic2D3V/Integrators/boris_uniform_b.cpp
 )
+
+check_file_list(${INTEGRATION_SRC} cpp "${INTEGRATION_SRC_FILES}" "")
 
 # ##############################################################################
 # Set up targets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,11 @@ set(UNIT_SRC_FILES
     ${UNIT_SRC}/nektar_interface/test_particle_mapping.cpp
     ${UNIT_SRC}/nektar_interface/test_utility_cartesian_mesh.cpp)
 
+check_file_list(${UNIT_SRC} cpp "${UNIT_SRC_FILES}" "")
+
+
+
+
 set(INTEGRATION_SRC ${CMAKE_CURRENT_SOURCE_DIR}/integration)
 set(INTEGRATION_SRC_FILES
     ${TEST_MAIN}


### PR DESCRIPTION
This is a compromise between globbing and manually specifying files in the cmake. It globs for files matching a pattern then checks that list against explicitly listed files and explicitly ignored files. Hence:

1) Missed files are obvious as the cmake warns the file exists but is not included (non-fatal).
2) None of the glob disadvantages for build dependencies or conflicts with temporary git files.
3) Lists files not added in an obvious way such that they can be copy/pasted into the cmakelists.
