### PR TITLE
Pin `hdf5` and `intel-oneapi-mkl` package versions+ document required oneAPI compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ source $SPACK_ROOT/share/spack/setup-env.sh
 Next, install the Intel compilers if they are not already present on
 your computer.
 ```bash
-spack install intel-oneapi-compilers
+spack install intel-oneapi-compilers@2022.1.0
 spack load intel-oneapi-compilers
 spack compiler find
 spack unload intel-oneapi-compilers

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,9 +5,9 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl ^py-numpy%intel
-    ^boost%intel ^py-cython%oneapi ^dpcpp ^scotch@6
-  - neso%gcc ^openblas ^hipsycl ^scotch@6
+  - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl@2022.1.0 ^py-numpy%intel
+    ^boost%intel ^py-cython%oneapi ^dpcpp ^scotch@6 ^hdf5@1.12.2
+  - neso%gcc ^openblas ^hipsycl ^scotch@6 ^hdf5@1.12.2
   view:
     gcc-hipsycl:
       root: views/gcc-hipsycl


### PR DESCRIPTION
# Description

Pins `hdf5` package to 1.12.2 and `intel-oneapi-mkl` to 2022.1.0 and adds pin to version 2022.1.0 to instructions for installing `intel-oneapi-compilers` package using Spack in README.

Fixes #210 and fixes ExCALIBUR-NEPTUNE/NESO-Particles#37 (also related to issue in #202).

With the updated spec here, I can build locally on Ubuntu 20.04 using both `gcc-11.3.0` and `oneapi-2022.1.0` compilers.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] API change (breaks downstream workflows and requires major semver bump)
- [ ] Requires documentation updates

# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.

- [ ] Test Foo in /test/path/to/file_for_test_Foo.cpp
 - Description of test Foo
- [ ] Test Bar in /test/path/to/file_for_test_Bar.cpp
 - Description of test Bar

**Test Configuration**:

* OS:
* SYCL implementation:
* MPI details:
* Hardware:

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new dependencies are automatically built for users via `cmake`
- [ ] I have used understandable variable names
- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [ ] I have run `black` against changes to `*.py`
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
