### PR TITLE
Fixes projection/evaluation iteration sets.

### DIFF
--- a/include/nektar_interface/function_basis_evaluation.hpp
+++ b/include/nektar_interface/function_basis_evaluation.hpp
@@ -99,8 +99,7 @@ protected:
     const int k_ndim = evaluation_type.get_ndim();
 
     sycl::range<2> cell_iterset_range{static_cast<size_t>(cells_iterset_size),
-                                      static_cast<size_t>(outer_size) *
-                                          static_cast<size_t>(local_size)};
+                                      static_cast<size_t>(outer_size)};
     sycl::range<2> local_iterset{1, local_size};
 
     auto event_loop = this->sycl_target->queue.submit([&](sycl::handler &cgh) {

--- a/include/nektar_interface/function_basis_projection.hpp
+++ b/include/nektar_interface/function_basis_projection.hpp
@@ -99,8 +99,7 @@ protected:
     const int k_ndim = project_type.get_ndim();
 
     sycl::range<2> cell_iterset_range{static_cast<size_t>(cells_iterset_size),
-                                      static_cast<size_t>(outer_size) *
-                                          static_cast<size_t>(local_size)};
+                                      static_cast<size_t>(outer_size)};
     sycl::range<2> local_iterset{1, local_size};
 
     auto event_loop = this->sycl_target->queue.submit([&](sycl::handler &cgh) {

--- a/test/integration/nektar_interface/test_particle_advection.cpp
+++ b/test/integration/nektar_interface/test_particle_advection.cpp
@@ -367,7 +367,7 @@ TEST_P(ParticleAdvection3D, Advection3D) {
         auto is_contained =
             geom->ContainsPoint(global_coord, local_coord, tol, dist);
 
-        ASSERT_TRUE(is_contained);
+        ASSERT_TRUE(is_contained || (dist < (tol * 10.0)));
       }
     }
   };


### PR DESCRIPTION
# Description
@seimtpow spotted the SYCL parallel for iteration sets were too large by a factor of local_size for the projection/evaluation kernels.
Made advection integration test more robust when particles are on cell boundary.

Fixes # (issue)

## Type of change
- Bug fix (non-breaking change)

# Testing
* Ran the existing unit and integration tests (hipsycl omp+cuda and intel). These will test that the iteration sets are sufficiently large.

