### PR TITLE
removed includes of CL/sycl.hpp

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,0 +1,311 @@
+{
+  "_help_parse": "Options affecting listfile parsing",
+  "parse": {
+    "_help_additional_commands": [
+      "Specify structure for custom cmake functions"
+    ],
+    "additional_commands": {
+      "foo": {
+        "flags": [
+          "BAR",
+          "BAZ"
+        ],
+        "kwargs": {
+          "HEADERS": "*",
+          "SOURCES": "*",
+          "DEPENDS": "*"
+        }
+      }
+    },
+    "_help_override_spec": [
+      "Override configurations per-command where available"
+    ],
+    "override_spec": {},
+    "_help_vartags": [
+      "Specify variable tags."
+    ],
+    "vartags": [],
+    "_help_proptags": [
+      "Specify property tags."
+    ],
+    "proptags": []
+  },
+  "_help_format": "Options affecting formatting.",
+  "format": {
+    "_help_disable": [
+      "Disable formatting entirely, making cmake-format a no-op"
+    ],
+    "disable": false,
+    "_help_line_width": [
+      "How wide to allow formatted cmake files"
+    ],
+    "line_width": 80,
+    "_help_tab_size": [
+      "How many spaces to tab for indent"
+    ],
+    "tab_size": 2,
+    "_help_use_tabchars": [
+      "If true, lines are indented using tab characters (utf-8",
+      "0x09) instead of <tab_size> space characters (utf-8 0x20).",
+      "In cases where the layout would require a fractional tab",
+      "character, the behavior of the  fractional indentation is",
+      "governed by <fractional_tab_policy>"
+    ],
+    "use_tabchars": false,
+    "_help_fractional_tab_policy": [
+      "If <use_tabchars> is True, then the value of this variable",
+      "indicates how fractional indentions are handled during",
+      "whitespace replacement. If set to 'use-space', fractional",
+      "indentation is left as spaces (utf-8 0x20). If set to",
+      "`round-up` fractional indentation is replaced with a single",
+      "tab character (utf-8 0x09) effectively shifting the column",
+      "to the next tabstop"
+    ],
+    "fractional_tab_policy": "use-space",
+    "_help_max_subgroups_hwrap": [
+      "If an argument group contains more than this many sub-groups",
+      "(parg or kwarg groups) then force it to a vertical layout."
+    ],
+    "max_subgroups_hwrap": 2,
+    "_help_max_pargs_hwrap": [
+      "If a positional argument group contains more than this many",
+      "arguments, then force it to a vertical layout."
+    ],
+    "max_pargs_hwrap": 6,
+    "_help_max_rows_cmdline": [
+      "If a cmdline positional group consumes more than this many",
+      "lines without nesting, then invalidate the layout (and nest)"
+    ],
+    "max_rows_cmdline": 2,
+    "_help_separate_ctrl_name_with_space": [
+      "If true, separate flow control names from their parentheses",
+      "with a space"
+    ],
+    "separate_ctrl_name_with_space": false,
+    "_help_separate_fn_name_with_space": [
+      "If true, separate function names from parentheses with a",
+      "space"
+    ],
+    "separate_fn_name_with_space": false,
+    "_help_dangle_parens": [
+      "If a statement is wrapped to more than one line, than dangle",
+      "the closing parenthesis on its own line."
+    ],
+    "dangle_parens": false,
+    "_help_dangle_align": [
+      "If the trailing parenthesis must be 'dangled' on its on",
+      "line, then align it to this reference: `prefix`: the start",
+      "of the statement,  `prefix-indent`: the start of the",
+      "statement, plus one indentation  level, `child`: align to",
+      "the column of the arguments"
+    ],
+    "dangle_align": "prefix",
+    "_help_min_prefix_chars": [
+      "If the statement spelling length (including space and",
+      "parenthesis) is smaller than this amount, then force reject",
+      "nested layouts."
+    ],
+    "min_prefix_chars": 4,
+    "_help_max_prefix_chars": [
+      "If the statement spelling length (including space and",
+      "parenthesis) is larger than the tab width by more than this",
+      "amount, then force reject un-nested layouts."
+    ],
+    "max_prefix_chars": 10,
+    "_help_max_lines_hwrap": [
+      "If a candidate layout is wrapped horizontally but it exceeds",
+      "this many lines, then reject the layout."
+    ],
+    "max_lines_hwrap": 2,
+    "_help_line_ending": [
+      "What style line endings to use in the output."
+    ],
+    "line_ending": "unix",
+    "_help_command_case": [
+      "Format command names consistently as 'lower' or 'upper' case"
+    ],
+    "command_case": "canonical",
+    "_help_keyword_case": [
+      "Format keywords consistently as 'lower' or 'upper' case"
+    ],
+    "keyword_case": "unchanged",
+    "_help_always_wrap": [
+      "A list of command names which should always be wrapped"
+    ],
+    "always_wrap": [],
+    "_help_enable_sort": [
+      "If true, the argument lists which are known to be sortable",
+      "will be sorted lexicographicall"
+    ],
+    "enable_sort": true,
+    "_help_autosort": [
+      "If true, the parsers may infer whether or not an argument",
+      "list is sortable (without annotation)."
+    ],
+    "autosort": false,
+    "_help_require_valid_layout": [
+      "By default, if cmake-format cannot successfully fit",
+      "everything into the desired linewidth it will apply the",
+      "last, most aggressive attempt that it made. If this flag is",
+      "True, however, cmake-format will print error, exit with non-",
+      "zero status code, and write-out nothing"
+    ],
+    "require_valid_layout": false,
+    "_help_layout_passes": [
+      "A dictionary mapping layout nodes to a list of wrap",
+      "decisions. See the documentation for more information."
+    ],
+    "layout_passes": {}
+  },
+  "_help_markup": "Options affecting comment reflow and formatting.",
+  "markup": {
+    "_help_bullet_char": [
+      "What character to use for bulleted lists"
+    ],
+    "bullet_char": "*",
+    "_help_enum_char": [
+      "What character to use as punctuation after numerals in an",
+      "enumerated list"
+    ],
+    "enum_char": ".",
+    "_help_first_comment_is_literal": [
+      "If comment markup is enabled, don't reflow the first comment",
+      "block in each listfile. Use this to preserve formatting of",
+      "your copyright/license statements."
+    ],
+    "first_comment_is_literal": false,
+    "_help_literal_comment_pattern": [
+      "If comment markup is enabled, don't reflow any comment block",
+      "which matches this (regex) pattern. Default is `None`",
+      "(disabled)."
+    ],
+    "literal_comment_pattern": null,
+    "_help_fence_pattern": [
+      "Regular expression to match preformat fences in comments",
+      "default= ``r'^\\s*([`~]{3}[`~]*)(.*)$'``"
+    ],
+    "fence_pattern": "^\\s*([`~]{3}[`~]*)(.*)$",
+    "_help_ruler_pattern": [
+      "Regular expression to match rulers in comments default=",
+      "``r'^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'``"
+    ],
+    "ruler_pattern": "^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$",
+    "_help_explicit_trailing_pattern": [
+      "If a comment line matches starts with this pattern then it",
+      "is explicitly a trailing comment for the preceding argument.",
+      "Default is '#<'"
+    ],
+    "explicit_trailing_pattern": "#<",
+    "_help_hashruler_min_length": [
+      "If a comment line starts with at least this many consecutive",
+      "hash characters, then don't lstrip() them off. This allows",
+      "for lazy hash rulers where the first hash char is not",
+      "separated by space"
+    ],
+    "hashruler_min_length": 10,
+    "_help_canonicalize_hashrulers": [
+      "If true, then insert a space between the first hash char and",
+      "remaining hash chars in a hash ruler, and normalize its",
+      "length to fill the column"
+    ],
+    "canonicalize_hashrulers": true,
+    "_help_enable_markup": [
+      "enable comment markup parsing and reflow"
+    ],
+    "enable_markup": true
+  },
+  "_help_lint": "Options affecting the linter",
+  "lint": {
+    "_help_disabled_codes": [
+      "a list of lint codes to disable"
+    ],
+    "disabled_codes": [],
+    "_help_function_pattern": [
+      "regular expression pattern describing valid function names"
+    ],
+    "function_pattern": "[0-9a-z_]+",
+    "_help_macro_pattern": [
+      "regular expression pattern describing valid macro names"
+    ],
+    "macro_pattern": "[0-9A-Z_]+",
+    "_help_global_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with global (cache) scope"
+    ],
+    "global_var_pattern": "[A-Z][0-9A-Z_]+",
+    "_help_internal_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with global scope (but internal semantic)"
+    ],
+    "internal_var_pattern": "_[A-Z][0-9A-Z_]+",
+    "_help_local_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "variables with local scope"
+    ],
+    "local_var_pattern": "[a-z][a-z0-9_]+",
+    "_help_private_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "privatedirectory variables"
+    ],
+    "private_var_pattern": "_[0-9a-z_]+",
+    "_help_public_var_pattern": [
+      "regular expression pattern describing valid names for public",
+      "directory variables"
+    ],
+    "public_var_pattern": "[A-Z][0-9A-Z_]+",
+    "_help_argument_var_pattern": [
+      "regular expression pattern describing valid names for",
+      "function/macro arguments and loop variables."
+    ],
+    "argument_var_pattern": "[a-z][a-z0-9_]+",
+    "_help_keyword_pattern": [
+      "regular expression pattern describing valid names for",
+      "keywords used in functions or macros"
+    ],
+    "keyword_pattern": "[A-Z][0-9A-Z_]+",
+    "_help_max_conditionals_custom_parser": [
+      "In the heuristic for C0201, how many conditionals to match",
+      "within a loop in before considering the loop a parser."
+    ],
+    "max_conditionals_custom_parser": 2,
+    "_help_min_statement_spacing": [
+      "Require at least this many newlines between statements"
+    ],
+    "min_statement_spacing": 1,
+    "_help_max_statement_spacing": [
+      "Require no more than this many newlines between statements"
+    ],
+    "max_statement_spacing": 2,
+    "max_returns": 6,
+    "max_branches": 12,
+    "max_arguments": 5,
+    "max_localvars": 15,
+    "max_statements": 50
+  },
+  "_help_encode": "Options affecting file encoding",
+  "encode": {
+    "_help_emit_byteorder_mark": [
+      "If true, emit the unicode byte-order mark (BOM) at the start",
+      "of the file"
+    ],
+    "emit_byteorder_mark": false,
+    "_help_input_encoding": [
+      "Specify the encoding of the input file. Defaults to utf-8"
+    ],
+    "input_encoding": "utf-8",
+    "_help_output_encoding": [
+      "Specify the encoding of the output file. Defaults to utf-8.",
+      "Note that cmake only claims to support utf-8 so be careful",
+      "when using anything else"
+    ],
+    "output_encoding": "utf-8"
+  },
+  "_help_misc": "Miscellaneous configurations options.",
+  "misc": {
+    "_help_per_command": [
+      "A dictionary containing any per-command configuration",
+      "overrides. Currently only `command_case` is supported."
+    ],
+    "per_command": {}
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,32 +16,33 @@ option(ENABLE_NESO_TESTS
 include(cmake/Sanitizers.cmake)
 include(cmake/CheckFileList.cmake)
 
-
-
 # ##############################################################################
 # Find dependencies
 # ##############################################################################
 
-#USE -DNESO_SYCL_VENDOR to chose implementation at gen time
-set(NESO_SYCL_VENDOR "Default" CACHE STRING "SYCL vendor to look for - required
+# USE -DNESO_SYCL_VENDOR to chose implementation at gen time
+set(NESO_SYCL_VENDOR
+    "Default"
+    CACHE STRING "SYCL vendor to look for - required
 if present")
-set(NESO_SYCL_VERSION "" CACHE STRING "SYCL version to look for")
+set(NESO_SYCL_VERSION
+    ""
+    CACHE STRING "SYCL version to look for")
 include(cmake/SYCL.cmake)
-if (NESO_SYCL_VENDOR MATCHES "Default")
-    find_sycl()
+if(NESO_SYCL_VENDOR MATCHES "Default")
+  find_sycl()
 else()
-    find_sycl(${NESO_SYCL_VENDOR} ${NESO_SYCL_VERSION})
+  find_sycl(${NESO_SYCL_VENDOR} ${NESO_SYCL_VERSION})
 endif()
 #
 # Use a custom FindNektar++ script to vide an interface target
 find_package(Nektar++ REQUIRED)
 
-#Add the NESO-Particles dependencies
+# Add the NESO-Particles dependencies
 find_package(NESO-Particles REQUIRED)
-#Alternativly just use as submodule
-#option(ENABLE_NESO_PARTICLES_TESTS OFF)
-#add_subdirectory(neso-particles)
-#include(neso-particles/cmake/restrict-keyword.cmake)
+# Alternativly just use as submodule option(ENABLE_NESO_PARTICLES_TESTS OFF)
+# add_subdirectory(neso-particles)
+# include(neso-particles/cmake/restrict-keyword.cmake)
 
 find_package(FFT REQUIRED)
 if(FFT_FOUND)
@@ -218,6 +219,7 @@ set(HEADER_FILES
     ${INC_DIR}/run_info.hpp
     ${INC_DIR}/simulation.hpp
     ${INC_DIR}/species.hpp
+    ${INC_DIR}/sycl_typedefs.hpp
     ${INC_DIR}/solvers/solver_callback_handler.hpp
     ${INC_DIR}/solvers/solver_runner.hpp
     ${INC_DIR}/velocity.hpp)
@@ -239,10 +241,7 @@ target_compile_options(${NESO_LIBRARY_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
 target_link_options(${NESO_LIBRARY_NAME} PUBLIC ${BUILD_TYPE_LINK_FLAGS})
 target_link_libraries(
   ${NESO_LIBRARY_NAME}
-  PUBLIC 
-     Nektar++::nektar++ 
-     fft::fft
-     NESO-Particles::NESO-Particles
+  PUBLIC Nektar++::nektar++ fft::fft NESO-Particles::NESO-Particles
   PRIVATE ${TEST_LIBRARIES})
 add_sycl_to_target(TARGET ${NESO_LIBRARY_NAME} SOURCES ${LIB_SRC_FILES})
 
@@ -262,7 +261,6 @@ add_sycl_to_target(TARGET ${PROJECT_NAME} SOURCES ${MAIN_SRC})
 
 # find MPI
 find_package(MPI REQUIRED)
-
 
 # Solvers
 add_subdirectory(solvers)

--- a/include/custom_types.hpp
+++ b/include/custom_types.hpp
@@ -1,13 +1,9 @@
 #ifndef NEPTUNE_CUSTOM_TYPES_H
 #define NEPTUNE_CUSTOM_TYPES_H
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
-
+#include "sycl_typedefs.hpp"
 #include <complex>
+#include <vector>
 
 // distribution function arrays
 using Complex = std::complex<double>;

--- a/include/diagnostics.hpp
+++ b/include/diagnostics.hpp
@@ -1,10 +1,10 @@
-class Diagnostics;
-
 #ifndef __DIAGNOSTICS_H__
 #define __DIAGNOSTICS_H__
+class Diagnostics;
 
 #include "mesh.hpp"
 #include "plasma.hpp"
+#include "sycl_typedefs.hpp"
 
 class Diagnostics {
 public:

--- a/include/fft_fftw.hpp
+++ b/include/fft_fftw.hpp
@@ -2,7 +2,7 @@
 #define NEPTUNE_FFTFFTW_H
 
 #include "custom_types.hpp"
-#include <CL/sycl.hpp>
+#include "sycl_typedefs.hpp"
 #include <fftw3.h>
 #include <vector>
 
@@ -15,7 +15,7 @@ private:
        auto in_a = in_b.get_access<sycl::access::mode::read>(cgh);
        auto out_a = out_b.get_access<sycl::access::mode::write>(cgh);
        cgh.parallel_for<class copy_to_buffer_k>(
-           sycl::range<1>{size_t(this->N)}, [=](cl::sycl::id<1> id) {
+           sycl::range<1>{size_t(this->N)}, [=](sycl::id<1> id) {
              reinterpret_cast<double(&)[2]>(out_a[id])[0] =
                  reinterpret_cast<const double(&)[2]>(in_a[id])[0];
              reinterpret_cast<double(&)[2]>(out_a[id])[1] =

--- a/include/fft_mkl.hpp
+++ b/include/fft_mkl.hpp
@@ -3,7 +3,7 @@
 
 #include "custom_types.hpp"
 #include "oneapi/mkl/dfti.hpp"
-#include <CL/sycl.hpp>
+#include "sycl_typedefs.hpp"
 
 class FFT {
 public:

--- a/include/interpolator.hpp
+++ b/include/interpolator.hpp
@@ -1,8 +1,7 @@
 #ifndef __INTERPOLATOR_H__
 #define __INTERPOLATOR_H__
-#include <vector>
-
 #include <neso_particles.hpp>
+#include <vector>
 
 namespace NP = NESO::Particles;
 namespace NESO {

--- a/include/linear_interpolator_1D.hpp
+++ b/include/linear_interpolator_1D.hpp
@@ -2,13 +2,12 @@
 #define __LINEAR_INTERPOLATOR_1D_H__
 
 #include "interpolator.hpp"
-#include <CL/sycl.hpp>
+#include "sycl_typedefs.hpp"
 #include <mpi.h>
 #include <neso_particles.hpp>
 #include <vector>
 
 using namespace NESO::Particles;
-using namespace cl;
 namespace NESO {
 
 /**

--- a/include/linear_interpolator_1D.hpp
+++ b/include/linear_interpolator_1D.hpp
@@ -2,7 +2,6 @@
 #define __LINEAR_INTERPOLATOR_1D_H__
 
 #include "interpolator.hpp"
-#include "sycl_typedefs.hpp"
 #include <mpi.h>
 #include <neso_particles.hpp>
 #include <vector>

--- a/include/mesh.hpp
+++ b/include/mesh.hpp
@@ -7,13 +7,8 @@ class Mesh;
 #include "fft_wrappers.hpp"
 #include "plasma.hpp"
 #include "species.hpp"
+#include "sycl_typedefs.hpp"
 #include <vector>
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 class Mesh {
 public:

--- a/include/nektar_interface/function_basis_evaluation.hpp
+++ b/include/nektar_interface/function_basis_evaluation.hpp
@@ -21,7 +21,6 @@ using namespace NESO::Particles;
 using namespace Nektar::LocalRegions;
 using namespace Nektar::StdRegions;
 
-#include <CL/sycl.hpp>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/include/nektar_interface/function_basis_projection.hpp
+++ b/include/nektar_interface/function_basis_projection.hpp
@@ -22,7 +22,6 @@ using namespace NESO::Particles;
 using namespace Nektar::LocalRegions;
 using namespace Nektar::StdRegions;
 
-#include <CL/sycl.hpp>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/include/plasma.hpp
+++ b/include/plasma.hpp
@@ -5,12 +5,7 @@ class Plasma;
 
 #include "mesh.hpp"
 #include "species.hpp"
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "sycl_typedefs.hpp"
 
 class Plasma {
 public:

--- a/include/run_info.hpp
+++ b/include/run_info.hpp
@@ -1,11 +1,6 @@
 #ifndef __RUNINFO_H__
 #define __RUNINFO_H__
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "sycl_typedefs.hpp"
 
 class RunInfo {
 public:

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -3,12 +3,7 @@
 #include "diagnostics.hpp"
 #include "mesh.hpp"
 #include "plasma.hpp"
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "sycl_typedefs.hpp"
 
 void initialize();
 void evolve(sycl::queue &q, Mesh &mesh, Plasma &plasma, FFT &fft,

--- a/include/species.hpp
+++ b/include/species.hpp
@@ -1,16 +1,10 @@
-class Species;
-
 #ifndef __SPECIES_H__
 #define __SPECIES_H__
+class Species;
 
 #include "mesh.hpp"
+#include "sycl_typedefs.hpp"
 #include "velocity.hpp"
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 class Species {
 public:

--- a/include/sycl_typedefs.hpp
+++ b/include/sycl_typedefs.hpp
@@ -1,0 +1,11 @@
+#ifndef _NESO_SYCL_TYPEDEFS_H_
+#define _NESO_SYCL_TYPEDEFS_H_
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+using namespace cl;
+#endif
+
+#endif

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -13,9 +13,11 @@ if [[ -f .clang-format && -f .cmake-format ]]; then
     find ./src ./include ./test ./solvers -iname CMakeLists.txt | xargs cmake-format  -c .cmake-format -i
     # black
     find ./python -iname \*.py | xargs black
+    exit 0;
 else
     echo "ERROR: The files .clang-format and .cmake-format do not exist. Please
        check this script is executed from the root directory of the git
        repository."
+    exit 1;
 fi
 

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -1,8 +1,21 @@
-# clang-format
-find ./src ./include ./test ./solvers -iname \*.hpp -o -iname \*.cpp | xargs clang-format -i
-# cmake-format
-cmake-format -i CMakeLists.txt # Do this one on it's own so we don't go into build etc
-find ./src ./include ./test ./solvers -iname CMakeLists.txt | xargs cmake-format -i
-# black
-find ./python -iname \*.py | xargs black
+# This script formats the source files in NESO. This script should be ran from
+# the root of the git repository. This script should be run as:
+#
+#   bash format_all.sh
+#
+# to format all source files. 
+
+if [[ -f .clang-format && -f .cmake-format ]]; then
+    # clang-format
+    find ./src ./include ./test ./solvers -iname \*.hpp -o -iname \*.cpp | xargs clang-format -i
+    # cmake-format
+    cmake-format -c .cmake-format -i CMakeLists.txt # Do this one on it's own so we don't go into build etc
+    find ./src ./include ./test ./solvers -iname CMakeLists.txt | xargs cmake-format  -c .cmake-format -i
+    # black
+    find ./python -iname \*.py | xargs black
+else
+    echo "ERROR: The files .clang-format and .cmake-format do not exist. Please
+       check this script is executed from the root directory of the git
+       repository."
+fi
 

--- a/solvers/Electrostatic2D3V/CMakeLists.txt
+++ b/solvers/Electrostatic2D3V/CMakeLists.txt
@@ -9,17 +9,13 @@ set(ELECTROSTATIC_2D3V_LIBRARY_NAME
 add_library(${ELECTROSTATIC_2D3V_LIBRARY_NAME} OBJECT
             ${CMAKE_CURRENT_LIST_DIR}/EquationSystems/PoissonPIC.cpp)
 
-target_include_directories(
-  ${ELECTROSTATIC_2D3V_LIBRARY_NAME}
-  PRIVATE ${CMAKE_SOURCE_DIR}/include)
-         
+target_include_directories(${ELECTROSTATIC_2D3V_LIBRARY_NAME}
+                           PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 target_link_libraries(
   ${ELECTROSTATIC_2D3V_LIBRARY_NAME}
-  PRIVATE ${NESO_LIBRARY_NAME} 
-          Nektar++::nektar++ 
-          NESO-Particles::NESO-Particles 
-          MPI::MPI_CXX)
+  PRIVATE ${NESO_LIBRARY_NAME} Nektar++::nektar++
+          NESO-Particles::NESO-Particles MPI::MPI_CXX)
 
 # create the solver binary
 file(GLOB Electrostatic2D3VSource
@@ -29,15 +25,11 @@ add_executable(${EXEC_TARGET_NAME} ${Electrostatic2D3VSource})
 
 target_link_libraries(
   ${EXEC_TARGET_NAME}
-  PRIVATE ${ELECTROSTATIC_2D3V_LIBRARY_NAME} 
-  Nektar++::nektar++
-  MPI::MPI_CXX 
-  NESO-Particles::NESO-Particles)
+  PRIVATE ${ELECTROSTATIC_2D3V_LIBRARY_NAME} Nektar++::nektar++ MPI::MPI_CXX
+          NESO-Particles::NESO-Particles)
 
-
-target_include_directories(
-    ${EXEC_TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
-
+target_include_directories(${EXEC_TARGET_NAME}
+                           PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 add_sycl_to_target(TARGET ${EXEC_TARGET_NAME} SOURCES
                    ${Electrostatic2D3VSource})

--- a/solvers/H3LAPD/CMakeLists.txt
+++ b/solvers/H3LAPD/CMakeLists.txt
@@ -12,12 +12,11 @@ set(SOLVER_LIBS
 add_library(${LIBRARY_NAME} OBJECT ${H3LAPD_SRC_FILES})
 target_compile_options(${LIBRARY_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
 target_link_libraries(${LIBRARY_NAME} PRIVATE Nektar++::nektar++
-    NESO-Particles::NESO-Particles)
+                                              NESO-Particles::NESO-Particles)
 # Top-level include dir for nektar-interface headers
 set(TOPLEVEL_INCLUDE_DIR "${INC_DIR}")
-target_include_directories(
-  ${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}
-                         ${TOPLEVEL_INCLUDE_DIR})
+target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}
+                                                  ${TOPLEVEL_INCLUDE_DIR})
 
 add_sycl_to_target(TARGET ${LIBRARY_NAME} SOURCES ${H3LAPD_SRC_FILES})
 
@@ -32,8 +31,8 @@ target_compile_options(${EXEC_TARGET_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
 # Linker options, target libs
 target_link_options(${EXEC_TARGET_NAME} PRIVATE ${BUILD_TYPE_LINK_FLAGS})
 target_link_libraries(
-    ${EXEC_TARGET_NAME} PRIVATE Nektar++::nektar++
-    NESO-Particles::NESO-Particles ${NESO_LIBRARY_NAME})
+  ${EXEC_TARGET_NAME} PRIVATE Nektar++::nektar++ NESO-Particles::NESO-Particles
+                              ${NESO_LIBRARY_NAME})
 
 add_sycl_to_target(TARGET ${EXEC_TARGET_NAME} SOURCES main.cpp)
 

--- a/solvers/SimpleSOL/CMakeLists.txt
+++ b/solvers/SimpleSOL/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Identify source files
 set(SIMPLE_SOL_SRC_FILES
-    EquationSystems/SOLSystem.cpp 
-    EquationSystems/SOLWithParticlesSystem.cpp
-    Forcing/SourceTerms.cpp 
-    SimpleSOL.cpp
-    )
+    EquationSystems/SOLSystem.cpp EquationSystems/SOLWithParticlesSystem.cpp
+    Forcing/SourceTerms.cpp SimpleSOL.cpp)
 
 # ============================== Object library ===============================
 # Put solver specific source in an object library so that tests can use it
@@ -14,14 +11,13 @@ set(SOLVER_LIBS
     CACHE INTERNAL "")
 add_library(${LIBRARY_NAME} OBJECT ${SIMPLE_SOL_SRC_FILES})
 target_compile_options(${LIBRARY_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
-target_link_libraries(${LIBRARY_NAME} PRIVATE Nektar++::nektar++
-                                              NESO-Particles::NESO-Particles
-                                              ${NESO_LIBRARY_NAME})
+target_link_libraries(
+  ${LIBRARY_NAME} PRIVATE Nektar++::nektar++ NESO-Particles::NESO-Particles
+                          ${NESO_LIBRARY_NAME})
 # Top-level include dir for nektar-interface headers
 set(TOPLEVEL_INCLUDE_DIR "${INC_DIR}")
-target_include_directories(
-  ${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}
-                          ${TOPLEVEL_INCLUDE_DIR})
+target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}
+                                                  ${TOPLEVEL_INCLUDE_DIR})
 
 add_sycl_to_target(TARGET ${LIBRARY_NAME} SOURCES ${SIMPLE_SOL_SRC_FILES})
 
@@ -36,7 +32,7 @@ target_compile_options(${EXEC_TARGET_NAME} PRIVATE ${BUILD_TYPE_COMPILE_FLAGS})
 # Linker options, target libs
 target_link_options(${EXEC_TARGET_NAME} PRIVATE ${BUILD_TYPE_LINK_FLAGS})
 target_link_libraries(
-    ${EXEC_TARGET_NAME} PRIVATE Nektar++::nektar++ NESO-Particles::NESO-Particles 
+  ${EXEC_TARGET_NAME} PRIVATE Nektar++::nektar++ NESO-Particles::NESO-Particles
                               ${NESO_LIBRARY_NAME})
 
 add_sycl_to_target(TARGET ${EXEC_TARGET_NAME} SOURCES main.cpp)

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -1,17 +1,8 @@
 /*
  * Module for dealing with diagnostics
  */
-
 #include "diagnostics.hpp"
-#include "mesh.hpp"
-#include "plasma.hpp"
 #include <cmath>
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 /*
  * Store simulation time as a vector

--- a/src/linear_interpolator_1D.cpp
+++ b/src/linear_interpolator_1D.cpp
@@ -1,11 +1,9 @@
 #include "linear_interpolator_1D.hpp"
-#include <CL/sycl.hpp>
 #include <mpi.h>
 #include <neso_particles.hpp>
 #include <vector>
 
 using namespace NESO::Particles;
-using namespace cl;
 namespace NESO {
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,7 @@
 #include "revision.hpp"
 #include "run_info.hpp"
 #include "simulation.hpp"
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "sycl_typedefs.hpp"
 #include <iostream>
 #include <string>
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3,19 +3,9 @@
  */
 
 #include "mesh.hpp"
-#include "custom_types.hpp"
-#include "fft_wrappers.hpp"
-#include "species.hpp"
 #include <cmath>
 #include <iostream>
 #include <string>
-#include <vector>
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 /*
  * Initialize mesh

--- a/src/plasma.cpp
+++ b/src/plasma.cpp
@@ -1,20 +1,8 @@
 /*
  * Module for dealing with particles
  */
-
 #include "plasma.hpp"
-#include "mesh.hpp"
 #include "species.hpp"
-#include <cmath>
-#include <iostream>
-#include <random>
-#include <string>
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 /*
  * Initialize particles

--- a/src/species.cpp
+++ b/src/species.cpp
@@ -3,17 +3,9 @@
  */
 
 #include "species.hpp"
-#include "mesh.hpp"
 #include <cmath>
-#include <iostream>
 #include <random>
 #include <string>
-
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 /*
  * Initialize particles

--- a/test/unit/test_1D_linear_interpolator.cpp
+++ b/test/unit/test_1D_linear_interpolator.cpp
@@ -1,5 +1,4 @@
 #include "linear_interpolator_1D.hpp"
-#include <CL/sycl.hpp>
 #include <gtest/gtest.h>
 #include <mpi.h>
 #include <neso_particles.hpp>


### PR DESCRIPTION
# Description

SYCL2020 states the includes should be of `SYCL/sycl.hpp`. Apart from the original 1D code (which performs it's own checks of if SYCL/sycl.hpp exists) NESO includes sycl transitively from NP. This PR removes includes and calls to "using namespace cl" which refer to how sycl worked pre 2020.

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change)

# Testing

Built and runs with hipsycl 0.9.4 and dpcpp 2021.

