### PR TITLE
Update EqnSysBase to work with nektar v5.5

### DIFF
--- a/include/nektar_interface/solver_base/eqnsys_base.hpp
+++ b/include/nektar_interface/solver_base/eqnsys_base.hpp
@@ -92,13 +92,16 @@ protected:
   /** @brief Write particle params to stdout on task 0. Ensures they appear just
    * after fluid params are written by nektar.
    *
+   * @param dump_initial_conditions Write initial conditions to file?
+   * default=true
+   *
    * */
-  virtual void v_DoInitialise() override {
+  virtual void v_DoInitialise(bool dump_initial_conditions) override {
     if (this->m_session->GetComm()->TreatAsRankZero() &&
         this->particles_enabled) {
       particle_sys->add_params_report();
     }
-    NEKEQNSYS::v_DoInitialise();
+    NEKEQNSYS::v_DoInitialise(dump_initial_conditions);
   }
 
   /**


### PR DESCRIPTION
# Description

Tweak a function sig to make base solver classes work with latest nektar.

## Type of change

- [x] Bug fix (non-breaking change)

# Testing

Existing unit an integration tests pass with gcc/hipsycl

OS: Ubuntu 22.04
Compiler: GCC 11.3.0
SYCL implementation: Hipsycl v0.9.2
MPI details: MPICH v4.0.2
Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
```

