### PR TITLE
PartSysBase and SimpleSOL+particles tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(LIB_SRC_FILES
     ${SRC_DIR}/nektar_interface/particle_cell_mapping/map_particles_common.cpp
     ${SRC_DIR}/nektar_interface/particle_cell_mapping/map_particles_host.cpp
     ${SRC_DIR}/nektar_interface/particle_cell_mapping/nektar_graph_local_mapper.cpp
+    ${SRC_DIR}/nektar_interface/solver_base/partsys_base.cpp
     ${SRC_DIR}/plasma.cpp
     ${SRC_DIR}/run_info.cpp
     ${SRC_DIR}/simulation.cpp

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -18,7 +18,7 @@
             <P> num_particle_steps_per_fluid_step = 1 </P>
             <P> num_particles_total = 100 </P>
             <P> num_particles_per_cell = -1 </P>
-            <P> particle_num_write_particle_steps = 4 </P>
+            <P> particle_output_freq = 4 </P>
             <P> particle_thermal_velocity = 1.0 </P>
             <P> particle_number_density = 3e18 </P>
             <P> particle_source_region_count = 2 </P>

--- a/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
+++ b/examples/SimpleSOL/2DWithParticles/2DWithParticles_config.xml
@@ -16,6 +16,11 @@
             <P> rhoInf         = 1.0         </P>
             <P> uInf           = 1.0         </P>
             <P> num_particle_steps_per_fluid_step = 1 </P>
+             <!--
+                Note that, for the SOLWithParticles equation system, num_particles_total sets the
+                number of particles added to the simulation per timestep per MPI rank, rather than
+                the total number of particles that will be added.
+            -->
             <P> num_particles_total = 100 </P>
             <P> num_particles_per_cell = -1 </P>
             <P> particle_output_freq = 4 </P>

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -37,10 +37,10 @@ public:
   SYCLTargetSharedPtr sycl_target;
 
   /// @brief Report particle parameter values (writes to stdout).
-  inline void add_params_report();
+  void add_params_report();
 
   /// @brief Clear up memory related to the particle system
-  inline void free();
+  void free();
 
   /**
    * @brief Return true if \p step is a scheduled output step, according to the
@@ -48,13 +48,13 @@ public:
    *
    * @ param step
    */
-  inline bool is_output_step(int step);
+  bool is_output_step(int step);
 
   /**
    *  @brief Write particle properties to an output file.
    *  @param step Time step number.
    */
-  inline void write(const int step);
+  void write(const int step);
 
 protected:
   /**
@@ -65,10 +65,10 @@ protected:
    *  @param comm (optional) MPI communicator to use - default MPI_COMM_WORLD.
    *
    */
-  inline PartSysBase(const LU::SessionReaderSharedPtr session,
-                     const SD::MeshGraphSharedPtr graph,
-                     ParticleSpec particle_spec, MPI_Comm comm = MPI_COMM_WORLD,
-                     PartSysOptions options = PartSysOptions());
+  PartSysBase(const LU::SessionReaderSharedPtr session,
+              const SD::MeshGraphSharedPtr graph, ParticleSpec particle_spec,
+              MPI_Comm comm = MPI_COMM_WORLD,
+              PartSysOptions options = PartSysOptions());
 
   /// Object used to map to/from nektar geometry ids to 0,N-1
   std::shared_ptr<CellIDTranslation> cell_id_translation;
@@ -99,11 +99,20 @@ protected:
    *  @param args Remaining arguments (variable length) should be sym instances
    *  indicating which ParticleDats are to be written.
    */
-  template <typename... T>
-  inline void init_output(std::string fname, T... args);
+  template <typename... T> void init_output(std::string fname, T... args) {
+    if (this->h5part) {
+      if (this->sycl_target->comm_pair.rank_parent == 0) {
+        nprint("Ignoring (duplicate?) call to init_output().");
+      }
+    } else {
+      // Create H5Part instance
+      this->h5part =
+          std::make_shared<H5Part>(fname, this->particle_group, args...);
+    }
+  }
 
   /// @brief Read some parameters associated with all particle systems.
-  inline void read_params();
+  void read_params();
 
   /**
    * @brief Store particle param values in a map.Values are reported later via
@@ -111,7 +120,12 @@ protected:
    * @param label Label to attach to the parameter
    * @param value Value of the parameter that was set
    */
-  template <typename T> inline void report_param(std::string label, T val);
+  template <typename T> void report_param(std::string label, T val) {
+    // form stringstream and store string value in private map
+    std::stringstream ss;
+    ss << val;
+    param_vals_to_report[label] = ss.str();
+  }
 
 private:
   /// Output frequency read from config file
@@ -123,146 +137,5 @@ private:
   std::map<std::string, std::string> param_vals_to_report;
 };
 
-inline PartSysBase::PartSysBase(const LU::SessionReaderSharedPtr session,
-                                const SD::MeshGraphSharedPtr graph,
-                                ParticleSpec particle_spec, MPI_Comm comm,
-                                PartSysOptions options)
-    : session(session), graph(graph), comm(comm), h5part_exists(false),
-      ndim(graph->GetSpaceDimension()) {
-
-  read_params();
-
-  // Store options
-  this->options = options;
-
-  // Create interface between particles and nektar++
-  this->particle_mesh_interface =
-      std::make_shared<ParticleMeshInterface>(graph, 0, this->comm);
-  extend_halos_fixed_offset(this->options.extend_halos_offset,
-                            this->particle_mesh_interface);
-  this->sycl_target =
-      std::make_shared<SYCLTarget>(0, particle_mesh_interface->get_comm());
-  this->nektar_graph_local_mapper = std::make_shared<NektarGraphLocalMapper>(
-      this->sycl_target, this->particle_mesh_interface);
-  this->domain = std::make_shared<Domain>(this->particle_mesh_interface,
-                                          this->nektar_graph_local_mapper);
-
-  // Create ParticleGroup
-  this->particle_group =
-      std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
-
-  // Set up map between cell indices
-  this->cell_id_translation = std::make_shared<CellIDTranslation>(
-      this->sycl_target, this->particle_group->cell_id_dat,
-      this->particle_mesh_interface);
-}
-
-/**
- * @details For each entry in the param_vals map (constructed via report_param),
- * write the value to stdout
- * @see also report_param()
- */
-inline void PartSysBase::add_params_report() {
-
-  std::cout << "Particle settings:" << std::endl;
-  for (auto const &[param_lbl, param_str_val] : this->param_vals_to_report) {
-    std::cout << "  " << param_lbl << ": " << param_str_val << std::endl;
-  }
-  std::cout << "============================================================="
-               "=========="
-            << std::endl
-            << std::endl;
-}
-
-inline void PartSysBase::free() {
-  if (this->h5part_exists) {
-    this->h5part->close();
-  }
-  this->particle_group->free();
-  this->sycl_target->free();
-  this->particle_mesh_interface->free();
-};
-
-template <typename... T>
-inline void PartSysBase::init_output(std::string fname, T... args) {
-  if (this->h5part_exists) {
-    if (this->sycl_target->comm_pair.rank_parent == 0) {
-      nprint("Ignoring (duplicate?) call to init_output().");
-    }
-  } else {
-    // Create H5Part instance
-    this->h5part =
-        std::make_shared<H5Part>(fname, this->particle_group, args...);
-    this->h5part_exists = true;
-  }
-}
-
-inline bool PartSysBase::is_output_step(int step) {
-  return this->output_freq > 0 && (step % this->output_freq) == 0;
-}
-
-inline void PartSysBase::read_params() {
-
-  // Read total number of particles / number per cell from config
-  int num_parts_per_cell, num_parts_tot;
-  this->session->LoadParameter(NUM_PARTS_TOT_STR, num_parts_tot, -1);
-  this->session->LoadParameter(NUM_PARTS_PER_CELL_STR, num_parts_per_cell, -1);
-
-  if (num_parts_tot > 0) {
-    this->num_parts_tot = num_parts_tot;
-    if (num_parts_per_cell > 0) {
-      nprint("Ignoring value of '" + NUM_PARTS_PER_CELL_STR +
-             "' because  "
-             "'" +
-             NUM_PARTS_TOT_STR + "' was specified.");
-    }
-  } else {
-    if (num_parts_per_cell > 0) {
-      // Determine the global number of elements
-      const int num_elements_local = this->graph->GetNumElements();
-      int num_elements_global;
-      MPICHK(MPI_Allreduce(&num_elements_local, &num_elements_global, 1,
-                           MPI_INT, MPI_SUM, this->comm));
-
-      // compute the global number of particles
-      this->num_parts_tot = ((int64_t)num_elements_global) * num_parts_per_cell;
-
-      report_param("Number of particles per cell/element", num_parts_per_cell);
-    } else {
-      nprint("Particles disabled (Neither '" + NUM_PARTS_TOT_STR +
-             "' or "
-             "'" +
-             NUM_PARTS_PER_CELL_STR + "' are set)");
-    }
-  }
-  report_param("Total number of particles", this->num_parts_tot);
-
-  // Output frequency
-  // ToDo Should probably be unsigned, but complicates use of LoadParameter
-  this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
-  report_param("Output frequency (steps)", this->output_freq);
-}
-
-template <typename T>
-inline void PartSysBase::report_param(std::string label, T val) {
-  // form stringstream and store string value in private map
-  std::stringstream ss;
-  ss << val;
-  param_vals_to_report[label] = ss.str();
-}
-
-inline void PartSysBase::write(const int step) {
-  if (this->h5part_exists) {
-    if (this->sycl_target->comm_pair.rank_parent == 0) {
-      nprint("Writing particle properties at step", step);
-    }
-    this->h5part->write();
-  } else {
-    if (this->sycl_target->comm_pair.rank_parent == 0) {
-      nprint("Ignoring call to write particle data because an output file "
-             "wasn't set up. init_output() not called?");
-    }
-  }
-};
 } // namespace NESO::Particles
 #endif

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -63,6 +63,16 @@ public:
   };
 
   /**
+   * @brief Return true if \p step is a scheduled output step, according to the
+   * frequency read from the config file, false otherwise
+   *
+   * @ param step
+   */
+  bool is_output_step(int step) {
+    return this->output_freq > 0 && (step % this->output_freq) == 0;
+  }
+
+  /**
    *  @brief Write particle properties to an output file.
    *
    *  @param step Time step number.
@@ -226,12 +236,15 @@ protected:
     report_param("Total number of particles", this->num_parts_tot);
 
     // Output frequency
-    int particle_output_freq;
-    this->session->LoadParameter(PART_OUTPUT_FREQ_STR, particle_output_freq, 0);
-    report_param("Output frequency (steps)", particle_output_freq);
+    // Should probably be unsigned, but
+    this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
+    report_param("Output frequency (steps)", this->output_freq);
   }
 
 private:
+  /// Output frequency read from config file
+  int output_freq;
+
   /// Map containing parameter name,value pairs to be written to stdout when the
   /// nektar equation system is initialised. Populated with report_param().
   std::map<std::string, std::string> param_vals_to_report;

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -80,8 +80,6 @@ protected:
   SD::MeshGraphSharedPtr graph;
   /// HDF5 output file
   std::shared_ptr<H5Part> h5part;
-  /// HDF5 output file flag
-  bool h5part_exists;
   /// Number of spatial dimensions being used
   const int ndim;
   /// Mapping instance to map particles into nektar++ elements.

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -43,10 +43,11 @@ public:
   void free();
 
   /**
-   * @brief Return true if \p step is a scheduled output step, according to the
-   * frequency read from the config file, false otherwise
+   * @brief Check whether particle output is scheduled for \p step.
    *
-   * @ param step
+   * @param step
+   * @returns true if \p step is a scheduled output step, according to the
+   * frequency read from the config file, false otherwise
    */
   bool is_output_step(int step);
 

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -32,35 +32,15 @@ public:
 
   /// NESO-Particles ParticleGroup
   ParticleGroupSharedPtr particle_group;
+
   /// Compute target
   SYCLTargetSharedPtr sycl_target;
 
-  /**
-   * @brief Write particle parameter values to stdout for any parameter.
-   *  @see also report_param()
-   */
-  inline void add_params_report() {
-    std::cout << "Particle settings:" << std::endl;
-    for (auto const &[param_lbl, param_str_val] : this->param_vals_to_report) {
-      std::cout << "  " << param_lbl << ": " << param_str_val << std::endl;
-    }
-    std::cout << "============================================================="
-                 "=========="
-              << std::endl
-              << std::endl;
-  }
+  /// @brief Report particle parameter values (writes to stdout).
+  inline void add_params_report();
 
-  /**
-   * @brief Clear up memory related to the particle system
-   */
-  inline void free() {
-    if (this->h5part_exists) {
-      this->h5part->close();
-    }
-    this->particle_group->free();
-    this->sycl_target->free();
-    this->particle_mesh_interface->free();
-  };
+  /// @brief Clear up memory related to the particle system
+  inline void free();
 
   /**
    * @brief Return true if \p step is a scheduled output step, according to the
@@ -68,72 +48,27 @@ public:
    *
    * @ param step
    */
-  bool is_output_step(int step) {
-    return this->output_freq > 0 && (step % this->output_freq) == 0;
-  }
+  inline bool is_output_step(int step);
 
   /**
    *  @brief Write particle properties to an output file.
-   *
    *  @param step Time step number.
    */
-  inline void write(const int step) {
-    if (this->h5part_exists) {
-      if (this->sycl_target->comm_pair.rank_parent == 0) {
-        nprint("Writing particle properties at step", step);
-      }
-      this->h5part->write();
-    } else {
-      if (this->sycl_target->comm_pair.rank_parent == 0) {
-        nprint("Ignoring call to write particle data because an output file "
-               "wasn't set up. init_output() not called?");
-      }
-    }
-  }
+  inline void write(const int step);
 
 protected:
   /**
-   * Protected constructor to prohibit direct instantiation.
-   *
+   * @brief Protected constructor to prohibit direct instantiation.
    *  @param session Nektar++ session to use for parameters and simulation
    * specification.
    *  @param graph Nektar++ MeshGraph on which particles exist.
    *  @param comm (optional) MPI communicator to use - default MPI_COMM_WORLD.
    *
    */
-  PartSysBase(const LU::SessionReaderSharedPtr session,
-              const SD::MeshGraphSharedPtr graph, ParticleSpec particle_spec,
-              MPI_Comm comm = MPI_COMM_WORLD,
-              PartSysOptions options = PartSysOptions())
-      : session(session), graph(graph), comm(comm), h5part_exists(false),
-        ndim(graph->GetSpaceDimension()) {
-
-    read_params();
-
-    // Store options
-    this->options = options;
-
-    // Create interface between particles and nektar++
-    this->particle_mesh_interface =
-        std::make_shared<ParticleMeshInterface>(graph, 0, this->comm);
-    extend_halos_fixed_offset(this->options.extend_halos_offset,
-                              this->particle_mesh_interface);
-    this->sycl_target =
-        std::make_shared<SYCLTarget>(0, particle_mesh_interface->get_comm());
-    this->nektar_graph_local_mapper = std::make_shared<NektarGraphLocalMapper>(
-        this->sycl_target, this->particle_mesh_interface);
-    this->domain = std::make_shared<Domain>(this->particle_mesh_interface,
-                                            this->nektar_graph_local_mapper);
-
-    // Create ParticleGroup
-    this->particle_group =
-        std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
-
-    // Set up map between cell indices
-    this->cell_id_translation = std::make_shared<CellIDTranslation>(
-        this->sycl_target, this->particle_group->cell_id_dat,
-        this->particle_mesh_interface);
-  }
+  inline PartSysBase(const LU::SessionReaderSharedPtr session,
+                     const SD::MeshGraphSharedPtr graph,
+                     ParticleSpec particle_spec, MPI_Comm comm = MPI_COMM_WORLD,
+                     PartSysOptions options = PartSysOptions());
 
   /// Object used to map to/from nektar geometry ids to 0,N-1
   std::shared_ptr<CellIDTranslation> cell_id_translation;
@@ -160,95 +95,174 @@ protected:
 
   /**
    * @brief Set up per-step particle output
-   *
    *  @param fname Output filename. Default is 'particle_trajectory.h5part'.
    *  @param args Remaining arguments (variable length) should be sym instances
    *  indicating which ParticleDats are to be written.
    */
   template <typename... T>
-  inline void init_output(std::string fname, T... args) {
-    if (this->h5part_exists) {
-      if (this->sycl_target->comm_pair.rank_parent == 0) {
-        nprint("Ignoring (duplicate?) call to init_output().");
-      }
-    } else {
-      // Create H5Part instance
-      this->h5part =
-          std::make_shared<H5Part>(fname, this->particle_group, args...);
-      this->h5part_exists = true;
-    }
-  }
+  inline void init_output(std::string fname, T... args);
+
+  /// @brief Read some parameters associated with all particle systems.
+  inline void read_params();
 
   /**
    * @brief Store particle param values in a map.Values are reported later via
    * add_params_report()
-   *
    * @param label Label to attach to the parameter
    * @param value Value of the parameter that was set
    */
-  template <typename T> void report_param(std::string label, T val) {
-    // form stringstream and store string value in private map
-    std::stringstream ss;
-    ss << val;
-    param_vals_to_report[label] = ss.str();
-  }
-
-  /**
-   * @brief Read some parameters associated with all particle systems.
-   */
-  inline void read_params() {
-
-    // Read total number of particles / number per cell from config
-    int num_parts_per_cell, num_parts_tot;
-    this->session->LoadParameter(NUM_PARTS_TOT_STR, num_parts_tot, -1);
-    this->session->LoadParameter(NUM_PARTS_PER_CELL_STR, num_parts_per_cell,
-                                 -1);
-
-    if (num_parts_tot > 0) {
-      this->num_parts_tot = num_parts_tot;
-      if (num_parts_per_cell > 0) {
-        nprint("Ignoring value of '" + NUM_PARTS_PER_CELL_STR +
-               "' because  "
-               "'" +
-               NUM_PARTS_TOT_STR + "' was specified.");
-      }
-    } else {
-      if (num_parts_per_cell > 0) {
-        // Determine the global number of elements
-        const int num_elements_local = this->graph->GetNumElements();
-        int num_elements_global;
-        MPICHK(MPI_Allreduce(&num_elements_local, &num_elements_global, 1,
-                             MPI_INT, MPI_SUM, this->comm));
-
-        // compute the global number of particles
-        this->num_parts_tot =
-            ((int64_t)num_elements_global) * num_parts_per_cell;
-
-        report_param("Number of particles per cell/element",
-                     num_parts_per_cell);
-      } else {
-        nprint("Particles disabled (Neither '" + NUM_PARTS_TOT_STR +
-               "' or "
-               "'" +
-               NUM_PARTS_PER_CELL_STR + "' are set)");
-      }
-    }
-    report_param("Total number of particles", this->num_parts_tot);
-
-    // Output frequency
-    // ToDo Should probably be unsigned, but complicates use of LoadParameter
-    this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
-    report_param("Output frequency (steps)", this->output_freq);
-  }
+  template <typename T> inline void report_param(std::string label, T val);
 
 private:
   /// Output frequency read from config file
   int output_freq;
-
-  /// Map containing parameter name,value pairs to be written to stdout when the
-  /// nektar equation system is initialised. Populated with report_param().
+  /**
+   * Map containing parameter name,value pairs to be written to stdout when
+   * the nektar equation system is initialised. Populated with report_param().
+   */
   std::map<std::string, std::string> param_vals_to_report;
 };
 
+inline PartSysBase::PartSysBase(const LU::SessionReaderSharedPtr session,
+                                const SD::MeshGraphSharedPtr graph,
+                                ParticleSpec particle_spec, MPI_Comm comm,
+                                PartSysOptions options)
+    : session(session), graph(graph), comm(comm), h5part_exists(false),
+      ndim(graph->GetSpaceDimension()) {
+
+  read_params();
+
+  // Store options
+  this->options = options;
+
+  // Create interface between particles and nektar++
+  this->particle_mesh_interface =
+      std::make_shared<ParticleMeshInterface>(graph, 0, this->comm);
+  extend_halos_fixed_offset(this->options.extend_halos_offset,
+                            this->particle_mesh_interface);
+  this->sycl_target =
+      std::make_shared<SYCLTarget>(0, particle_mesh_interface->get_comm());
+  this->nektar_graph_local_mapper = std::make_shared<NektarGraphLocalMapper>(
+      this->sycl_target, this->particle_mesh_interface);
+  this->domain = std::make_shared<Domain>(this->particle_mesh_interface,
+                                          this->nektar_graph_local_mapper);
+
+  // Create ParticleGroup
+  this->particle_group =
+      std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+
+  // Set up map between cell indices
+  this->cell_id_translation = std::make_shared<CellIDTranslation>(
+      this->sycl_target, this->particle_group->cell_id_dat,
+      this->particle_mesh_interface);
+}
+
+/**
+ * @details For each entry in the param_vals map (constructed via report_param),
+ * write the value to stdout
+ * @see also report_param()
+ */
+inline void PartSysBase::add_params_report() {
+
+  std::cout << "Particle settings:" << std::endl;
+  for (auto const &[param_lbl, param_str_val] : this->param_vals_to_report) {
+    std::cout << "  " << param_lbl << ": " << param_str_val << std::endl;
+  }
+  std::cout << "============================================================="
+               "=========="
+            << std::endl
+            << std::endl;
+}
+
+inline void PartSysBase::free() {
+  if (this->h5part_exists) {
+    this->h5part->close();
+  }
+  this->particle_group->free();
+  this->sycl_target->free();
+  this->particle_mesh_interface->free();
+};
+
+template <typename... T>
+inline void PartSysBase::init_output(std::string fname, T... args) {
+  if (this->h5part_exists) {
+    if (this->sycl_target->comm_pair.rank_parent == 0) {
+      nprint("Ignoring (duplicate?) call to init_output().");
+    }
+  } else {
+    // Create H5Part instance
+    this->h5part =
+        std::make_shared<H5Part>(fname, this->particle_group, args...);
+    this->h5part_exists = true;
+  }
+}
+
+inline bool PartSysBase::is_output_step(int step) {
+  return this->output_freq > 0 && (step % this->output_freq) == 0;
+}
+
+inline void PartSysBase::read_params() {
+
+  // Read total number of particles / number per cell from config
+  int num_parts_per_cell, num_parts_tot;
+  this->session->LoadParameter(NUM_PARTS_TOT_STR, num_parts_tot, -1);
+  this->session->LoadParameter(NUM_PARTS_PER_CELL_STR, num_parts_per_cell, -1);
+
+  if (num_parts_tot > 0) {
+    this->num_parts_tot = num_parts_tot;
+    if (num_parts_per_cell > 0) {
+      nprint("Ignoring value of '" + NUM_PARTS_PER_CELL_STR +
+             "' because  "
+             "'" +
+             NUM_PARTS_TOT_STR + "' was specified.");
+    }
+  } else {
+    if (num_parts_per_cell > 0) {
+      // Determine the global number of elements
+      const int num_elements_local = this->graph->GetNumElements();
+      int num_elements_global;
+      MPICHK(MPI_Allreduce(&num_elements_local, &num_elements_global, 1,
+                           MPI_INT, MPI_SUM, this->comm));
+
+      // compute the global number of particles
+      this->num_parts_tot = ((int64_t)num_elements_global) * num_parts_per_cell;
+
+      report_param("Number of particles per cell/element", num_parts_per_cell);
+    } else {
+      nprint("Particles disabled (Neither '" + NUM_PARTS_TOT_STR +
+             "' or "
+             "'" +
+             NUM_PARTS_PER_CELL_STR + "' are set)");
+    }
+  }
+  report_param("Total number of particles", this->num_parts_tot);
+
+  // Output frequency
+  // ToDo Should probably be unsigned, but complicates use of LoadParameter
+  this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
+  report_param("Output frequency (steps)", this->output_freq);
+}
+
+template <typename T>
+inline void PartSysBase::report_param(std::string label, T val) {
+  // form stringstream and store string value in private map
+  std::stringstream ss;
+  ss << val;
+  param_vals_to_report[label] = ss.str();
+}
+
+inline void PartSysBase::write(const int step) {
+  if (this->h5part_exists) {
+    if (this->sycl_target->comm_pair.rank_parent == 0) {
+      nprint("Writing particle properties at step", step);
+    }
+    this->h5part->write();
+  } else {
+    if (this->sycl_target->comm_pair.rank_parent == 0) {
+      nprint("Ignoring call to write particle data because an output file "
+             "wasn't set up. init_output() not called?");
+    }
+  }
+};
 } // namespace NESO::Particles
 #endif

--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -236,7 +236,7 @@ protected:
     report_param("Total number of particles", this->num_parts_tot);
 
     // Output frequency
-    // Should probably be unsigned, but
+    // ToDo Should probably be unsigned, but complicates use of LoadParameter
     this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
     report_param("Output frequency (steps)", this->output_freq);
   }

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
@@ -43,8 +43,6 @@ protected:
   bool mass_recording_enabled;
   // Number of particle timesteps per fluid timestep.
   int m_num_part_substeps;
-  // Number of time steps between particle trajectory step writes.
-  int m_num_write_particle_steps;
   // Particle timestep size.
   double m_part_timestep;
 

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
@@ -21,8 +21,9 @@ public:
   /// Callback handler to call user defined callbacks.
   SolverCallbackHandler<SOLWithParticlesSystem> solver_callback_handler;
 
-  // Object that allows optional recording of stats related to mass conservation
-  std::shared_ptr<MassRecording<MR::DisContField>> m_diag_mass_recording;
+  /// Object that allows optional recording of stats related to mass
+  /// conservation
+  std::shared_ptr<MassRecording<MR::DisContField>> diag_mass_recording;
 
   /// Creates an instance of this class.
   static SU::EquationSystemSharedPtr
@@ -39,18 +40,17 @@ public:
                          const SD::MeshGraphSharedPtr &graph);
 
 protected:
-  // Flag to toggle mass conservation checking
-  bool mass_recording_enabled;
-  // Number of particle timesteps per fluid timestep.
-  int m_num_part_substeps;
-  // Particle timestep size.
-  double m_part_timestep;
-
   /*
   Source fields cast to DisContFieldSharedPtr, indexed by name, for use in
   particle evaluation/projection methods
  */
-  std::map<std::string, MR::DisContFieldSharedPtr> m_discont_fields;
+  std::map<std::string, MR::DisContFieldSharedPtr> discont_fields;
+  // Flag to toggle mass conservation checking
+  bool mass_recording_enabled;
+  // Number of particle timesteps per fluid timestep.
+  int num_part_substeps;
+  // Particle timestep size.
+  double part_timestep;
 
   void update_temperature();
 

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -343,6 +343,12 @@ public:
     report_param("Number of sampling lines per (Gaussian) source",
                  this->source_line_bin_count);
     report_param("Thermal velocity", this->particle_thermal_velocity);
+
+    // Setup particle output
+    init_output("SimpleSOL_particle_trajectory.h5part", Sym<REAL>("POSITION"),
+                Sym<INT>("CELL_ID"), Sym<REAL>("COMPUTATIONAL_WEIGHT"),
+                Sym<REAL>("VELOCITY"), Sym<INT>("NESO_MPI_RANK"),
+                Sym<INT>("PARTICLE_ID"), Sym<REAL>("NESO_REFERENCE_POSITIONS"));
   };
 
   /**
@@ -463,31 +469,6 @@ public:
         this->particle_group->add_particles_local(line_distribution);
       }
     }
-  }
-
-  /**
-   *  Write current particle state to trajectory.
-   *
-   *  @param step Time step number.
-   */
-  inline void write(const int step) {
-
-    if (this->sycl_target->comm_pair.rank_parent == 0) {
-      nprint("Writing particle trajectory:", step);
-    }
-
-    if (!this->h5part_exists) {
-      // Create instance to write particle data to h5 file
-      this->h5part = std::make_shared<H5Part>(
-          "SimpleSOL_particle_trajectory.h5part", this->particle_group,
-          Sym<REAL>("POSITION"), Sym<INT>("CELL_ID"),
-          Sym<REAL>("COMPUTATIONAL_WEIGHT"), Sym<REAL>("VELOCITY"),
-          Sym<INT>("NESO_MPI_RANK"), Sym<INT>("PARTICLE_ID"),
-          Sym<REAL>("NESO_REFERENCE_POSITIONS"));
-      this->h5part_exists = true;
-    }
-
-    this->h5part->write();
   }
 
   /**

--- a/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
+++ b/solvers/SimpleSOL/ParticleSystems/neutral_particles.hpp
@@ -329,6 +329,20 @@ public:
                 this->sycl_target, tmp_init));
       }
     }
+
+    report_param("Num particles added per step per rank (set via " +
+                     PartSysBase::NUM_PARTS_TOT_STR + "!)",
+                 this->num_parts_tot);
+    report_param("Number of (Gaussian) particle source regions",
+                 this->source_region_count);
+    report_param("Separation between each source and the domain edge (in "
+                 "domain lengths)",
+                 this->source_region_offset);
+    report_param("Width of source regions (in domain lengths)",
+                 particle_source_region_gaussian_width);
+    report_param("Number of sampling lines per (Gaussian) source",
+                 this->source_line_bin_count);
+    report_param("Thermal velocity", this->particle_thermal_velocity);
   };
 
   /**

--- a/src/nektar_interface/solver_base/partsys_base.cpp
+++ b/src/nektar_interface/solver_base/partsys_base.cpp
@@ -12,7 +12,7 @@ PartSysBase::PartSysBase(const LU::SessionReaderSharedPtr session,
                          const SD::MeshGraphSharedPtr graph,
                          ParticleSpec particle_spec, MPI_Comm comm,
                          PartSysOptions options)
-    : session(session), graph(graph), comm(comm), h5part_exists(false),
+    : session(session), graph(graph), comm(comm),
       ndim(graph->GetSpaceDimension()) {
 
   read_params();
@@ -60,7 +60,7 @@ void PartSysBase::add_params_report() {
 }
 
 void PartSysBase::free() {
-  if (this->h5part_exists) {
+  if (this->h5part) {
     this->h5part->close();
   }
   this->particle_group->free();
@@ -115,7 +115,7 @@ void PartSysBase::read_params() {
 }
 
 void PartSysBase::write(const int step) {
-  if (this->h5part_exists) {
+  if (this->h5part) {
     if (this->sycl_target->comm_pair.rank_parent == 0) {
       nprint("Writing particle properties at step", step);
     }

--- a/src/nektar_interface/solver_base/partsys_base.cpp
+++ b/src/nektar_interface/solver_base/partsys_base.cpp
@@ -1,0 +1,130 @@
+#include "../../../include/nektar_interface/solver_base/partsys_base.hpp"
+#include <SolverUtils/EquationSystem.h>
+#include <mpi.h>
+#include <nektar_interface/geometry_transport/halo_extension.hpp>
+#include <nektar_interface/particle_interface.hpp>
+#include <neso_particles.hpp>
+#include <type_traits>
+
+namespace NESO::Particles {
+
+PartSysBase::PartSysBase(const LU::SessionReaderSharedPtr session,
+                         const SD::MeshGraphSharedPtr graph,
+                         ParticleSpec particle_spec, MPI_Comm comm,
+                         PartSysOptions options)
+    : session(session), graph(graph), comm(comm), h5part_exists(false),
+      ndim(graph->GetSpaceDimension()) {
+
+  read_params();
+
+  // Store options
+  this->options = options;
+
+  // Create interface between particles and nektar++
+  this->particle_mesh_interface =
+      std::make_shared<ParticleMeshInterface>(graph, 0, this->comm);
+  extend_halos_fixed_offset(this->options.extend_halos_offset,
+                            this->particle_mesh_interface);
+  this->sycl_target =
+      std::make_shared<SYCLTarget>(0, particle_mesh_interface->get_comm());
+  this->nektar_graph_local_mapper = std::make_shared<NektarGraphLocalMapper>(
+      this->sycl_target, this->particle_mesh_interface);
+  this->domain = std::make_shared<Domain>(this->particle_mesh_interface,
+                                          this->nektar_graph_local_mapper);
+
+  // Create ParticleGroup
+  this->particle_group =
+      std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+
+  // Set up map between cell indices
+  this->cell_id_translation = std::make_shared<CellIDTranslation>(
+      this->sycl_target, this->particle_group->cell_id_dat,
+      this->particle_mesh_interface);
+}
+
+/**
+ * @details For each entry in the param_vals map (constructed via report_param),
+ * write the value to stdout
+ * @see also report_param()
+ */
+void PartSysBase::add_params_report() {
+
+  std::cout << "Particle settings:" << std::endl;
+  for (auto const &[param_lbl, param_str_val] : this->param_vals_to_report) {
+    std::cout << "  " << param_lbl << ": " << param_str_val << std::endl;
+  }
+  std::cout << "============================================================="
+               "=========="
+            << std::endl
+            << std::endl;
+}
+
+void PartSysBase::free() {
+  if (this->h5part_exists) {
+    this->h5part->close();
+  }
+  this->particle_group->free();
+  this->sycl_target->free();
+  this->particle_mesh_interface->free();
+}
+
+bool PartSysBase::is_output_step(int step) {
+  return this->output_freq > 0 && (step % this->output_freq) == 0;
+}
+
+void PartSysBase::read_params() {
+
+  // Read total number of particles / number per cell from config
+  int num_parts_per_cell, num_parts_tot;
+  this->session->LoadParameter(NUM_PARTS_TOT_STR, num_parts_tot, -1);
+  this->session->LoadParameter(NUM_PARTS_PER_CELL_STR, num_parts_per_cell, -1);
+
+  if (num_parts_tot > 0) {
+    this->num_parts_tot = num_parts_tot;
+    if (num_parts_per_cell > 0) {
+      nprint("Ignoring value of '" + NUM_PARTS_PER_CELL_STR +
+             "' because  "
+             "'" +
+             NUM_PARTS_TOT_STR + "' was specified.");
+    }
+  } else {
+    if (num_parts_per_cell > 0) {
+      // Determine the global number of elements
+      const int num_elements_local = this->graph->GetNumElements();
+      int num_elements_global;
+      MPICHK(MPI_Allreduce(&num_elements_local, &num_elements_global, 1,
+                           MPI_INT, MPI_SUM, this->comm));
+
+      // compute the global number of particles
+      this->num_parts_tot = ((int64_t)num_elements_global) * num_parts_per_cell;
+
+      report_param("Number of particles per cell/element", num_parts_per_cell);
+    } else {
+      nprint("Particles disabled (Neither '" + NUM_PARTS_TOT_STR +
+             "' or "
+             "'" +
+             NUM_PARTS_PER_CELL_STR + "' are set)");
+    }
+  }
+  report_param("Total number of particles", this->num_parts_tot);
+
+  // Output frequency
+  // ToDo Should probably be unsigned, but complicates use of LoadParameter
+  this->session->LoadParameter(PART_OUTPUT_FREQ_STR, this->output_freq, 0);
+  report_param("Output frequency (steps)", this->output_freq);
+}
+
+void PartSysBase::write(const int step) {
+  if (this->h5part_exists) {
+    if (this->sycl_target->comm_pair.rank_parent == 0) {
+      nprint("Writing particle properties at step", step);
+    }
+    this->h5part->write();
+  } else {
+    if (this->sycl_target->comm_pair.rank_parent == 0) {
+      nprint("Ignoring call to write particle data because an output file "
+             "wasn't set up. init_output() not called?");
+    }
+  }
+};
+} // namespace NESO::Particles

--- a/test/integration/solvers/SimpleSOL/test_SimpleSOL.hpp
+++ b/test/integration/solvers/SimpleSOL/test_SimpleSOL.hpp
@@ -197,7 +197,7 @@ protected:
 struct SOLWithParticlesMassConservationPre
     : public NESO::SolverCallback<SOLWithParticlesSystem> {
   void call(SOLWithParticlesSystem *state) {
-    state->m_diag_mass_recording->compute_initial_fluid_mass();
+    state->diag_mass_recording->compute_initial_fluid_mass();
   }
 };
 
@@ -205,7 +205,7 @@ struct SOLWithParticlesMassConservationPost
     : public NESO::SolverCallback<SOLWithParticlesSystem> {
   std::vector<double> mass_error;
   void call(SOLWithParticlesSystem *state) {
-    auto md = state->m_diag_mass_recording;
+    auto md = state->diag_mass_recording;
     const double mass_particles = md->compute_particle_mass();
     const double mass_fluid = md->compute_fluid_mass();
     const double mass_total = mass_particles + mass_fluid;


### PR DESCRIPTION
# Description
Move handling of particle output frequency into particle system base class.

## Type of change

- [x] Refactoring/cleanup
~- [ ] Bug fix (non-breaking change)~
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] API change (breaks downstream workflows and requires major semver bump)~
~- [ ] Requires documentation updates~

# Testing

No new tests. Passes existing unit and integration tests.

Test Configuration:

OS: Ubuntu 22.04
Compiler: GCC 11.3.0 / OneAPI v2022.1.0
SYCL implementation: Hipsycl v0.9.2 / DPC++ v2022.1.0
MPI details: MPICH v4.0.2
Hardware: CPU (Intel Alder Lake)

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] I have used understandable variable names
- [x] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] Any new dependencies are automatically built for users via `cmake`~
~- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`~
~- [ ] I have run `black` against changes to `*.py`~
~- [ ] I have made corresponding changes to the documentation~
```

