### PR TITLE
CMake: Fix `Find*` modules not handling arguments correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,8 @@ find_package(NESO-Particles REQUIRED)
 # include(neso-particles/cmake/restrict-keyword.cmake)
 
 find_package(FFT REQUIRED)
-if(FFT_FOUND)
-  message(STATUS "USING FFT implementation ${FFT_IMPLEMENTATION}")
-  string(TOUPPER ${FFT_IMPLEMENTATION} FFT_UPPER)
-  set(FFT_FLAG NESO_${FFT_UPPER}_FFT)
-endif()
+string(TOUPPER ${FFT_IMPLEMENTATION} FFT_UPPER)
+set(FFT_FLAG NESO_${FFT_UPPER}_FFT)
 
 # Uncomment this code to list ALL cmake variables
 # get_cmake_property(_variableNames VARIABLES) list (SORT _variableNames)

--- a/cmake/FindFFT.cmake
+++ b/cmake/FindFFT.cmake
@@ -12,8 +12,6 @@
 # fft::fft
 #
 
-set(FFT_FOUND FALSE)
-
 # Hack to deal with the fact Intel seems to be inconsistent with whether it
 # prefers you to use dpcpp or icpx directly. MKL requires the compiler to be
 # dpcpp, but the DPCPP cmake files actually prefer that icpx is used.
@@ -47,7 +45,6 @@ add_library(fft INTERFACE)
 add_library(fft::fft ALIAS fft)
 if(MKL_FOUND)
   set(FFT_IMPLEMENTATION "Intel_MKL")
-  set(FFT_FOUND TRUE)
   if (TARGET MKL::MKL_SYCL) 
       target_link_libraries(fft INTERFACE MKL::MKL_SYCL)
   else()
@@ -58,7 +55,9 @@ else()
   pkg_search_module(FFTW QUIET fftw3 IMPORTED_TARGET)
   if(FFTW_FOUND)
     set(FFT_IMPLEMENTATION fftw)
-    set(FFT_FOUND TRUE)
     target_link_libraries(fft INTERFACE PkgConfig::FFTW)
   endif()
 endif()
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFT DEFAULT_MSG FFT_IMPLEMENTATION)

--- a/cmake/FindNektar++.cmake
+++ b/cmake/FindNektar++.cmake
@@ -33,3 +33,6 @@ if(Nektar++_FOUND AND NOT TARGET Nektar++::nektar++)
     INTERFACE ${NEKTAR++_INCLUDE_DIRS} ${NEKTAR++_TP_FILTERED_INCLUDE_DIRS}
               ${SOLVER_INC_DIR})
 endif()
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Nektar++ DEFAULT_MSG NEKTAR++_LIBRARIES NEKTAR++_INCLUDE_DIRS)


### PR DESCRIPTION
`REQUIRED` argument to `find_package` was not being handled for custom `Find*` modules. These modules should contain a call to `find_package_handle_standard_args`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] API change (breaks downstream workflows and requires major semver bump)
- [ ] Requires documentation updates
