### PR TITLE
Temp hack to get around issue of linking to Nektar++ Solver libraries

### DIFF
--- a/solvers/Electrostatic2D3V/EquationSystems/PoissonPIC.cpp
+++ b/solvers/Electrostatic2D3V/EquationSystems/PoissonPIC.cpp
@@ -10,6 +10,16 @@ string PoissonPIC::className2 =
     GetEquationSystemFactory().RegisterCreatorFunction("SteadyDiffusion",
                                                        PoissonPIC::create);
 
+//FIXME: Hack to get around nektar++ solver linking issue 
+//Just pick something big so it won't clash
+constexpr int enumPoissonPIC = 102;
+std::string PoissonPIC::eq_name1 = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "PoissonPIC",enumPoissonPIC);
+constexpr int enumSteadyDiffusion = 103;
+std::string PoissonPIC::eq_name2 = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "SteadyDiffusion",enumSteadyDiffusion);
+
+
 PoissonPIC::PoissonPIC(const LibUtilities::SessionReaderSharedPtr &pSession,
                        const SpatialDomains::MeshGraphSharedPtr &pGraph)
     : EquationSystem(pSession, pGraph), m_factors() {

--- a/solvers/Electrostatic2D3V/EquationSystems/PoissonPIC.hpp
+++ b/solvers/Electrostatic2D3V/EquationSystems/PoissonPIC.hpp
@@ -26,6 +26,9 @@ public:
   /// Name of class
   static std::string className1;
   static std::string className2;
+  /// For enum
+  static std::string eq_name1;
+  static std::string eq_name2;
 
   virtual ~PoissonPIC();
   /**

--- a/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.cpp
+++ b/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.cpp
@@ -11,6 +11,11 @@ std::string HW2Din3DSystem::class_name =
         "(2D) Hasegawa-Wakatani equation system as an intermediate step "
         "towards the full H3-LAPD problem");
 
+//FIXME: Hack to get around nektar++ solver linking issue 
+//Just pick something big so it won't clash
+constexpr int enumHW2Din3DSystem = 105;
+std::string HW2Din3DSystem::eq_name = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "HW2Din3D",enumHW2Din3DSystem);
 HW2Din3DSystem::HW2Din3DSystem(const LU::SessionReaderSharedPtr &session,
                                const SD::MeshGraphSharedPtr &graph)
     : UnsteadySystem(session, graph), AdvectionSystem(session, graph),

--- a/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.cpp
+++ b/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.cpp
@@ -15,7 +15,7 @@ std::string HW2Din3DSystem::class_name =
 //Just pick something big so it won't clash
 constexpr int enumHW2Din3DSystem = 105;
 std::string HW2Din3DSystem::eq_name = 
- Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "HW2Din3D",enumHW2Din3DSystem);
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "2Din3DHW",enumHW2Din3DSystem);
 HW2Din3DSystem::HW2Din3DSystem(const LU::SessionReaderSharedPtr &session,
                                const SD::MeshGraphSharedPtr &graph)
     : UnsteadySystem(session, graph), AdvectionSystem(session, graph),

--- a/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.hpp
+++ b/solvers/H3LAPD/EquationSystems/HW2Din3DSystem.hpp
@@ -44,6 +44,8 @@ public:
 
   /// Name of class
   static std::string class_name;
+  /// For enum
+  static std::string eq_name;
   /// Object that allows optional recording of energy and enstrophy growth rates
   std::shared_ptr<GrowthRatesRecorder<MR::DisContField>>
       m_diag_growth_rates_recorder;

--- a/solvers/H3LAPD/EquationSystems/LAPDSystem.cpp
+++ b/solvers/H3LAPD/EquationSystems/LAPDSystem.cpp
@@ -6,6 +6,12 @@ std::string LAPDSystem::class_name =
     SU::GetEquationSystemFactory().RegisterCreatorFunction(
         "LAPD", LAPDSystem::create, "LAPD equation system");
 
+//FIXME: Hack to get around nektar++ solver linking issue 
+//Just pick something big so it won't clash
+constexpr int enumLAPDSystem = 104;
+std::string LAPDSystem::eq_name = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "LAPD",enumLAPDSystem);
+
 LAPDSystem::LAPDSystem(const LU::SessionReaderSharedPtr &session,
                        const SD::MeshGraphSharedPtr &graph)
     : UnsteadySystem(session, graph), AdvectionSystem(session, graph),

--- a/solvers/H3LAPD/EquationSystems/LAPDSystem.hpp
+++ b/solvers/H3LAPD/EquationSystems/LAPDSystem.hpp
@@ -33,6 +33,8 @@ public:
 
   /// Name of class
   static std::string class_name;
+  /// For enum
+  static std::string eq_name;
 
 protected:
   LAPDSystem(const LU::SessionReaderSharedPtr &session,

--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.cpp
@@ -8,6 +8,11 @@ std::string SOLSystem::class_name =
     SU::GetEquationSystemFactory().RegisterCreatorFunction(
         "SOL", SOLSystem::create, "SOL equations in conservative variables.");
 
+constexpr int enumSOL = 101;
+std::string SOLSystem::eq_name = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "SOL",enumSOL);
+
+
 SOLSystem::SOLSystem(const LU::SessionReaderSharedPtr &session,
                      const SD::MeshGraphSharedPtr &graph)
     : TimeEvoEqnSysBase<SU::UnsteadySystem, NeutralParticleSystem>(session,

--- a/solvers/SimpleSOL/EquationSystems/SOLSystem.hpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLSystem.hpp
@@ -40,6 +40,8 @@ public:
 
   /// Name of class.
   static std::string class_name;
+  /// For enum
+  static std::string eq_name;
 
 protected:
   SOLSystem(const LU::SessionReaderSharedPtr &session,

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.cpp
@@ -3,10 +3,18 @@
 #include "SOLWithParticlesSystem.hpp"
 
 namespace NESO::Solvers {
+
 std::string SOLWithParticlesSystem::class_name =
     SU::GetEquationSystemFactory().RegisterCreatorFunction(
         "SOLWithParticles", SOLWithParticlesSystem::create,
         "SOL equations with particle source terms.");
+
+//FIXME: Hack to get around nektar++ solver linking issue 
+//Just pick something big so it won't clash
+constexpr int enumSOLWithParticles = 100;
+std::string SOLWithParticlesSystem::eq_name = 
+ Nektar::LibUtilities::SessionReader::RegisterEnumValue("EqType", "SOLWithParticles",enumSOLWithParticles);
+
 
 SOLWithParticlesSystem::SOLWithParticlesSystem(
     const LU::SessionReaderSharedPtr &session,

--- a/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
+++ b/solvers/SimpleSOL/EquationSystems/SOLWithParticlesSystem.hpp
@@ -17,6 +17,8 @@ public:
 
   /// Name of class.
   static std::string class_name;
+  /// For enum
+  static std::string eq_name;
 
   /// Callback handler to call user defined callbacks.
   SolverCallbackHandler<SOLWithParticlesSystem> solver_callback_handler;


### PR DESCRIPTION
Linking to solver libraries that register enums for their solvers mean that every eqtype has to have a enum registered. 

Should be considered a temporary fix - Will open issue with full description of problem for consideration