### PR TITLE
Faster algorithms for CPU and GPU for basis projection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,20 @@ project(
   LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 option(ENABLE_NESO_TESTS
        "Build unit tests for this project and register with ctest" ON)
+#TODO REMOVE THIS JUST FOR TESTING
+option(NESO_USE_NEW_PROJECTION "Use new projection" OFF)
+option(ENABLE_NESO_BENCHMARKS "Build benchmarks" OFF)
+option(NESO_USE_NESO_PARTICLES_SUBMODULE "Consume neso-particles directly from
+the submodule" OFF)
+if (NESO_USE_NEW_PROJECTION)
+    add_compile_definitions(NESO_USE_NEW_PROJECTION)
+endif()
 
 # Various sanitizers, including coverage and address sanitizer
 include(cmake/Sanitizers.cmake)
@@ -37,12 +46,13 @@ endif()
 #
 # Use a custom FindNektar++ script to vide an interface target
 find_package(Nektar++ REQUIRED)
-
-# Add the NESO-Particles dependencies
-find_package(NESO-Particles REQUIRED)
-# Alternativly just use as submodule option(ENABLE_NESO_PARTICLES_TESTS OFF)
-# add_subdirectory(neso-particles)
-# include(neso-particles/cmake/restrict-keyword.cmake)
+if (NESO_USE_NESO_PARTICLES_SUBMODULE)
+option(ENABLE_NESO_PARTICLES_TESTS OFF)
+add_subdirectory(neso-particles)
+include(neso-particles/cmake/restrict-keyword.cmake)
+else()
+find_package(NESO-Particles REQURED)
+endif()
 
 find_package(FFT REQUIRED)
 if(FFT_FOUND)
@@ -179,6 +189,26 @@ set(HEADER_FILES
     ${INC_DIR}/nektar_interface/function_basis_projection.hpp
     ${INC_DIR}/nektar_interface/function_evaluation.hpp
     ${INC_DIR}/nektar_interface/function_projection.hpp
+    ${INC_DIR}/nektar_interface/function_basis_projection_alt.hpp
+    ${INC_DIR}/nektar_interface/projection/basis/basis.hpp
+    ${INC_DIR}/nektar_interface/projection/basis/static_for.hpp
+    ${INC_DIR}/nektar_interface/projection/basis/jacobi.hpp
+    ${INC_DIR}/nektar_interface/projection/basis/power.hpp #not used yet 
+    ${INC_DIR}/nektar_interface/projection/auto_switch.hpp
+    ${INC_DIR}/nektar_interface/projection/algorithm_types.hpp
+    ${INC_DIR}/nektar_interface/projection/shapes.hpp
+    ${INC_DIR}/nektar_interface/projection/tri.hpp
+    ${INC_DIR}/nektar_interface/projection/quad.hpp
+    ${INC_DIR}/nektar_interface/projection/hex.hpp
+    ${INC_DIR}/nektar_interface/projection/pyramid.hpp
+    ${INC_DIR}/nektar_interface/projection/prism.hpp
+    ${INC_DIR}/nektar_interface/projection/tet.hpp
+    ${INC_DIR}/nektar_interface/projection/util.hpp
+    ${INC_DIR}/nektar_interface/projection/constants.hpp
+
+    ${INC_DIR}/nektar_interface/projection/restrict.hpp
+    ${INC_DIR}/nektar_interface/projection/unroll.hpp
+    ${INC_DIR}/nektar_interface/projection/device_data.hpp
     ${INC_DIR}/nektar_interface/geometry_transport/geometry_packing_utility.hpp
     ${INC_DIR}/nektar_interface/geometry_transport/geometry_container_3d.hpp
     ${INC_DIR}/nektar_interface/geometry_transport/geometry_local_remote_3d.hpp
@@ -294,6 +324,9 @@ add_subdirectory(solvers)
 if(ENABLE_NESO_TESTS)
   enable_testing()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
+endif()
+if (ENABLE_NESO_BENCHMARKS)
+	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
 endif()
 
 # ##############################################################################

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,24 @@
+include(FetchContent)
+#Get googlebenchmark suite
+option(BENCHMARK_DOWNLOAD_DEPENENCIES ON)
+option(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+option(BENCHMARK_ENABLE_TESTING OFF)
+FetchContent_Declare(benchmark
+    GIT_SHALLOW TRUE
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG main #TODO: Change this to a specific commit
+    )
+FetchContent_MakeAvailable(benchmark)
+
+set(PROJECTION_SRC projection/args.cpp projection/benchmark.cpp)
+
+add_executable(projection_bench 
+	${PROJECTION_SRC})
+add_sycl_to_target(TARGET projection_bench SOURCE ${PROJECTION_BENCH})
+target_link_libraries(projection_bench 
+PUBLIC
+	benchmark::benchmark
+	${NESO_LIBRARY_NAME}
+)
+
+

--- a/benchmark/projection/args.cpp
+++ b/benchmark/projection/args.cpp
@@ -1,0 +1,82 @@
+#include "include/args.hpp"
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+static int get_int(char *str) {
+  char *endptr = nullptr;
+  auto n = strtol(str, &endptr, 10);
+  if (n == LONG_MIN || n == LONG_MAX) {
+    perror("Argument under/overflow");
+  }
+  if (endptr == str) {
+    // NOTE: I think this is not safe using printf with user input
+    // so don't use code for anything "real"
+    fprintf(stderr, "%s is not valid value\n", str);
+    exit(1);
+  }
+  if (n <= 0) {
+    fprintf(stderr, "argument values must be positive\n");
+    exit(1);
+  }
+  // TODO: should I just change to long everywhere?
+  if (n > INT_MAX) {
+    fprintf(stderr, "Max argument value is %d\n", INT_MAX);
+    exit(1);
+  }
+  return (int)n;
+}
+
+void print_options(CmdArgs const &arg) {
+  printf("Options:\n"
+         "number of cells %d\n"
+         "number of active cells (have particles) %d\n"
+         "max particles per cell %d\n"
+         "min particles per cell %d\n",
+         arg.ncell, arg.active_cell, arg.max_per_cell, arg.min_per_cell);
+}
+
+CmdArgs get_args(int argc, char **argv, bool print) {
+  CmdArgs arg;
+  int opt = -1;
+  while ((opt = getopt(argc, argv, "m:n:a:f:t:l:hse")) != -1) {
+    switch (opt) {
+    case 'n':
+      arg.ncell = get_int(optarg);
+      break;
+    case 'a':
+      arg.active_cell = get_int(optarg);
+      break;
+    case 't':
+      arg.max_per_cell = get_int(optarg);
+      break;
+    case 'l':
+      arg.min_per_cell = get_int(optarg);
+      break;
+    case '-':
+      goto END;
+    default:
+    case 'h':
+      printf("-n\tnumber of cells\n"
+             "-a\tnumber of cells with particles\n"
+             "-t\tmax number of particles in cell\n"
+             "-l\tmin number of particles in cell\n"
+             "-h\tprint this message\n"
+             "--\tNEED THIS AS last option before any --benchmark_* "
+             "options\n"); // hack to make it work with googlebenchmark
+                           // options
+      exit(0);
+    }
+  }
+
+END:
+  if (arg.active_cell > arg.ncell) {
+    fprintf(stderr,
+            "Active cells (%d) is greater than number of cells (%d)\n"
+            "Resetting active cells = ncell\n",
+            arg.active_cell, arg.ncell);
+  }
+  if (print)
+    print_options(arg);
+  return arg;
+}

--- a/benchmark/projection/benchmark.cpp
+++ b/benchmark/projection/benchmark.cpp
@@ -1,0 +1,90 @@
+#include <benchmark/benchmark.h>
+#include <sycl/sycl.hpp>
+
+namespace Nektar::LibUtilities {
+enum ShapeType {
+  eNoShapeType,
+  ePoint,
+  eSegment,
+  eTriangle,
+  eQuadrilateral,
+  eTetrahedron,
+  ePyramid,
+  ePrism,
+  eHexahedron
+};
+}
+#include "include/args.hpp"
+#include "include/create_data.hpp"
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/constants.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+#include <nektar_interface/projection/shapes.hpp>
+
+static CmdArgs args;
+
+// mock the nektar shapes (not really used anyway)
+
+using namespace NESO::Project;
+
+template <int nmode, typename T, typename Shape>
+void bm_project(benchmark::State &state) {
+  auto Q = sycl::queue{sycl::default_selector_v};
+  auto [data, ptrs] = create_data<nmode, T, Shape>(
+      Q, args.ncell, args.min_per_cell, args.max_per_cell);
+  std::optional<sycl::event> ev;
+  for (auto _ : state) {
+    if ((ev = Shape::algorithm::template project<nmode, T, 1, 1, Shape>(data, 0,
+                                                                        Q))) {
+      ev.value().wait();
+    } else {
+      state.SkipWithError("Projection failed");
+      break;
+    }
+  }
+  free_data(Q, ptrs);
+}
+
+#define MAKE_BENCH_SET(type, shape, alg)                                       \
+  BENCHMARK(bm_project<3, type, shape<alg>>);                                  \
+  BENCHMARK(bm_project<4, type, shape<alg>>);                                  \
+  BENCHMARK(bm_project<5, type, shape<alg>>);                                  \
+  BENCHMARK(bm_project<6, type, shape<alg>>);                                  \
+  BENCHMARK(bm_project<7, type, shape<alg>>);                                  \
+  BENCHMARK(bm_project<8, type, shape<alg>>);
+
+MAKE_BENCH_SET(double, eQuad, ThreadPerCell);
+MAKE_BENCH_SET(double, eTriangle, ThreadPerCell);
+MAKE_BENCH_SET(double, eHex, ThreadPerCell);
+MAKE_BENCH_SET(double, ePyramid, ThreadPerCell);
+MAKE_BENCH_SET(double, ePrism, ThreadPerCell);
+MAKE_BENCH_SET(double, eTet, ThreadPerCell);
+
+MAKE_BENCH_SET(float, eQuad, ThreadPerCell);
+MAKE_BENCH_SET(float, eTriangle, ThreadPerCell);
+MAKE_BENCH_SET(float, eHex, ThreadPerCell);
+MAKE_BENCH_SET(float, ePyramid, ThreadPerCell);
+MAKE_BENCH_SET(float, ePrism, ThreadPerCell);
+MAKE_BENCH_SET(float, eTet, ThreadPerCell);
+
+MAKE_BENCH_SET(double, eQuad, ThreadPerDof);
+MAKE_BENCH_SET(double, eTriangle, ThreadPerDof);
+MAKE_BENCH_SET(double, eHex, ThreadPerDof);
+MAKE_BENCH_SET(double, ePyramid, ThreadPerDof);
+MAKE_BENCH_SET(double, ePrism, ThreadPerDof);
+MAKE_BENCH_SET(double, eTet, ThreadPerDof);
+
+MAKE_BENCH_SET(float, eQuad, ThreadPerDof);
+MAKE_BENCH_SET(float, eTriangle, ThreadPerDof);
+MAKE_BENCH_SET(float, eHex, ThreadPerDof);
+MAKE_BENCH_SET(float, ePyramid, ThreadPerDof);
+MAKE_BENCH_SET(float, ePrism, ThreadPerDof);
+MAKE_BENCH_SET(float, eTet, ThreadPerDof);
+
+int main(int argc, char **argv) {
+  args = get_args(argc, argv, true);
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/benchmark/projection/include/args.hpp
+++ b/benchmark/projection/include/args.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+struct CmdArgs {
+  int ncell = 2024;
+  int active_cell = 20;
+  int max_per_cell = 2000;
+  int min_per_cell = 600;
+};
+
+CmdArgs get_args(int argc, char **argv, bool print = false);

--- a/benchmark/projection/include/create_data.hpp
+++ b/benchmark/projection/include/create_data.hpp
@@ -1,0 +1,168 @@
+#include <nektar_interface/projection/device_data.hpp>
+#include <random>
+#include <sycl/sycl.hpp>
+#include <utility>
+#include <vector>
+
+#define SEED 32423
+
+template <typename T>
+static inline void random_fill_array(T *d_ptr, int size, sycl::queue &q) {
+  assert(size > 0);
+  std::mt19937 random(SEED * SEED);
+  std::uniform_real_distribution<T> dist(-20.0, 20.0);
+  std::vector<T> vec(size, 0.0);
+  std::generate(vec.begin(), vec.end(), [&]() { return dist(random); });
+  q.copy<T>(vec.data(), d_ptr, size).wait_and_throw();
+}
+
+static inline std::vector<int> dense_dist(int ncell, int min_per_cell,
+                                          int max_per_cell) {
+  std::mt19937 random(SEED); // device());
+  std::uniform_int_distribution<> pdist(min_per_cell, max_per_cell);
+  std::uniform_int_distribution<> cdist(0, ncell);
+  std::vector<int> npar(ncell, 0);
+
+  std::for_each(npar.begin(), npar.end(), [&](int &n) { n = pdist(random); });
+  return npar;
+}
+
+static inline std::vector<int> simplesol_dist(int ncell, int active_cells,
+                                              int min_per_cell,
+                                              int max_per_cell) {
+  if (ncell == active_cells)
+    return dense_dist(ncell, min_per_cell, min_per_cell);
+  if (ncell < active_cells) {
+    fprintf(stderr, "Active cells > total cells\n");
+    exit(1);
+  }
+  // std::random_device device;
+  assert(min_per_cell > 0);
+  assert(max_per_cell >= min_per_cell);
+  std::mt19937 random(2983); // device());
+  std::uniform_int_distribution<> pdist(min_per_cell, max_per_cell);
+  std::uniform_int_distribution<> cdist(0, ncell);
+  std::vector<int> npar(ncell, 0);
+
+  // anticipating ncell >> active_cells so this should be ok
+  while (active_cells > 0) {
+    int cell = cdist(random);
+    if (npar[cell] == 0) {
+      active_cells--;
+      npar[cell] = pdist(random);
+    }
+  }
+  return npar;
+}
+
+template <int nmode, typename T, typename Shape>
+static inline auto create_data(sycl::queue &Q, int ncell, int min_per_cell,
+                               int max_per_cell, int active_cells = -1) {
+  // Shove all the pointers in a vector so we can free them later
+
+  std::vector<void *> all_pointers;
+
+  // Par per cell
+  int *par_per_cell = sycl::malloc_device<int>(ncell, Q);
+  assert(par_per_cell);
+  all_pointers.push_back((void *)par_per_cell);
+  int max_row = 0;
+  std::vector<int> host_par_per_cell;
+  if (active_cells < 0 || active_cells == ncell) {
+    host_par_per_cell = dense_dist(ncell, min_per_cell, max_per_cell);
+    max_row =
+        *std::max_element(host_par_per_cell.begin(), host_par_per_cell.end());
+    Q.copy<int>(host_par_per_cell.data(), par_per_cell, ncell).wait();
+  } else {
+    host_par_per_cell =
+        simplesol_dist(ncell, active_cells, min_per_cell, max_per_cell);
+    max_row =
+        *std::max_element(host_par_per_cell.begin(), host_par_per_cell.end());
+    Q.copy<int>(host_par_per_cell.data(), par_per_cell, ncell).wait();
+  }
+  // DOFS
+  T *dofs =
+      sycl::malloc_device<T>(ncell * Shape::template get_ndof<nmode>(), Q);
+  assert(dofs);
+  all_pointers.push_back((void *)dofs);
+  Q.fill(dofs, T{0.0}, ncell * Shape::template get_ndof<nmode>())
+      .wait_and_throw();
+
+  // DOF offsets ndof per cell but scanned
+  auto host_offsets =
+      std::vector<int>(ncell, Shape::template get_ndof<nmode>());
+  std::exclusive_scan(host_offsets.begin(), host_offsets.end(),
+                      host_offsets.begin(), 0);
+  int *dof_offsets = sycl::malloc_device<int>(ncell, Q);
+  assert(dof_offsets);
+  all_pointers.push_back((void *)dof_offsets);
+  Q.copy<int>(host_offsets.data(), dof_offsets, ncell).wait_and_throw();
+
+  // Cell ids
+  int *cell_ids = sycl::malloc_device<int>(ncell, Q);
+  assert(cell_ids);
+  all_pointers.push_back((void *)cell_ids);
+  Q.parallel_for<>(ncell, [=](sycl::id<1> id) { cell_ids[id] = id; }).wait();
+  // Particle postion pointers
+  auto host_data_ptrs = std::vector<T **>(ncell, nullptr);
+  for (int i = 0; i < ncell; ++i) {
+    // allocate data arrays for positions
+    T *par_data[3] = {nullptr};
+    par_data[0] = sycl::malloc_device<T>(host_par_per_cell[i], Q);
+    assert(par_data[0]);
+    random_fill_array(par_data[0], host_par_per_cell[i], Q);
+    all_pointers.push_back((void *)par_data[0]);
+    if (Shape::dim > 1) {
+      par_data[1] = sycl::malloc_device<T>(host_par_per_cell[i], Q);
+      assert(par_data[1]);
+      random_fill_array(par_data[1], host_par_per_cell[i], Q);
+      all_pointers.push_back((void *)par_data[1]);
+    }
+    if (Shape::dim > 2) {
+      par_data[2] = sycl::malloc_device<T>(host_par_per_cell[i], Q);
+      random_fill_array(par_data[2], host_par_per_cell[i], Q);
+      assert(par_data[2]);
+      all_pointers.push_back((void *)par_data[2]);
+    }
+    // allocate array for cells
+    host_data_ptrs[i] = sycl::malloc_device<T *>(Shape::dim, Q);
+    assert(host_data_ptrs[i]);
+    all_pointers.push_back((void *)host_data_ptrs[i]);
+    Q.copy<T *>(par_data, host_data_ptrs[i], Shape::dim).wait_and_throw();
+  }
+  auto positions = sycl::malloc_device<T **>(ncell, Q);
+  assert(positions);
+  all_pointers.push_back((void *)positions);
+  Q.copy<T **>(host_data_ptrs.data(), positions, ncell).wait_and_throw();
+
+  // Particle value data
+
+  auto host_value_ptrs = std::vector<T **>(ncell, nullptr);
+  for (int i = 0; i < ncell; ++i) {
+    // allocate value arrays for positions
+    T *par_vals[1] = {nullptr};
+    par_vals[0] = sycl::malloc_device<T>(host_par_per_cell[i], Q);
+    assert(par_vals);
+    all_pointers.push_back((void *)par_vals[0]);
+    random_fill_array(par_vals[0], host_par_per_cell[i], Q);
+    host_value_ptrs[i] = sycl::malloc_device<T *>(1, Q);
+    assert(host_value_ptrs[i]);
+    all_pointers.push_back((void *)host_value_ptrs[i]);
+    Q.copy<T *>(par_vals, host_value_ptrs[i], 1).wait_and_throw();
+  }
+  auto input = sycl::malloc_device<T **>(ncell, Q);
+  assert(input);
+  all_pointers.push_back((void *)input);
+  Q.copy<T **>(host_value_ptrs.data(), input, ncell).wait_and_throw();
+
+  return std::pair(NESO::Project::DeviceData<T>(dofs, dof_offsets, ncell,
+                                                max_row, cell_ids, par_per_cell,
+                                                positions, input),
+                   all_pointers);
+}
+
+static inline void free_data(sycl::queue &Q, std::vector<void *> &data) {
+  for (auto &p : data) {
+    sycl::free(p, Q);
+  }
+}

--- a/include/nektar_interface/function_basis_projection_alt.hpp
+++ b/include/nektar_interface/function_basis_projection_alt.hpp
@@ -1,0 +1,179 @@
+#pragma once
+#include <cstdlib>
+#include <memory>
+#include <neso_particles.hpp>
+#include <optional>
+
+#include <LocalRegions/QuadExp.h>
+#include <LocalRegions/TriExp.h>
+#include <StdRegions/StdExpansion2D.h>
+
+#include "expansion_looping/basis_evaluate_base.hpp"
+
+#include <sycl/sycl.hpp>
+#include <string>
+
+#include "projection/algorithm_types.hpp"
+#include "projection/auto_switch.hpp"
+#include "projection/constants.hpp"
+#include "projection/device_data.hpp"
+#include "projection/shapes.hpp"
+
+using REAL = double;
+
+namespace NESO {
+
+template <typename T>
+void fill_device_buffer_and_wait(T *ptr, T val, int size,
+                                 sycl::queue &queue) {
+  sycl::range range(size);
+  queue
+      .submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<>(range, [=](sycl::id<1> id) { ptr[id] = val; });
+      })
+      .wait();
+}
+
+template <typename T> class FunctionProjectBasis : public BasisEvaluateBase<T> {
+
+  template <typename U>
+  Project::DeviceData<U> get_device_data(ParticleGroupSharedPtr &particle_group,
+                                         Sym<U> sym,
+                                         ShapeType const shape_type) {
+    auto mpi_rank_dat = particle_group->mpi_rank_dat;
+    auto cell_ids = this->map_shape_to_dh_cells.at(shape_type)->d_buffer.ptr;
+    auto ncell = this->map_shape_to_count.at(shape_type);
+    return Project::DeviceData<U>(
+        this->dh_global_coeffs.d_buffer.ptr,
+        this->dh_coeffs_offsets.d_buffer.ptr, ncell,
+        mpi_rank_dat->cell_dat.get_nrow_max(), cell_ids,
+        mpi_rank_dat->d_npart_cell,
+        (*particle_group)[Sym<REAL>("NESO_REFERENCE_POSITIONS")]
+            ->cell_dat.device_ptr(),
+        (*particle_group)[sym]->cell_dat.device_ptr());
+  }
+
+  template <typename Shape, typename U>
+  inline sycl::event project_inner(ParticleGroupSharedPtr particle_group,
+                                       Sym<U> sym, int const component) {
+
+    ShapeType const shape_type = Shape::shape_type;
+
+    const int cells_iterset_size = this->map_shape_to_count.at(shape_type);
+    if (cells_iterset_size == 0) {
+      return sycl::event{};
+    }
+
+    auto device_data =
+        this->get_device_data<U>(particle_group, sym, shape_type);
+
+    const auto k_nummodes =
+        this->dh_nummodes.h_buffer
+            .ptr[this->map_shape_to_dh_cells.at(shape_type)->h_buffer.ptr[0]];
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(
+        // template param for generated switch/case
+        k_nummodes,
+        // return value
+        event,
+        // function to call
+        Shape::algorithm::template project,
+        // function arguments
+        FUNCTION_ARGS(device_data, component, this->sycl_target->queue),
+        // template arguments to append to param to switch
+        U, Project::Constants::alpha, Project::Constants::beta, Shape);
+    // TODO: Do something if project fails i.e. option is empty
+    // For example could try run the other algorithm
+    return event.value_or(sycl::event());
+  }
+
+public:
+  /// Disable (implicit) copies.
+  FunctionProjectBasis(const FunctionProjectBasis &st) = delete;
+  /// Disable (implicit) copies.
+  FunctionProjectBasis &operator=(FunctionProjectBasis const &a) = delete;
+
+  /**
+   * Constructor to create instance to project onto Nektar++ fields.
+   *
+   * @param field Example Nektar++ field of the same mesh and function space as
+   * the destination fields that this instance will be called with.
+   * @param mesh ParticleMeshInterface constructed over same mesh as the
+   * function.
+   * @param cell_id_translation Map between NESO-Particles cells and Nektar++
+   * cells.
+   */
+  FunctionProjectBasis(std::shared_ptr<T> field,
+                       ParticleMeshInterfaceSharedPtr mesh,
+                       CellIDTranslationSharedPtr cell_id_translation)
+      : BasisEvaluateBase<T>(field, mesh, cell_id_translation) {}
+
+  template <typename U, typename V>
+  void
+  project(ParticleGroupSharedPtr particle_group, Sym<U> sym,
+          int const component, // TODO: <component> should be a vector or
+                               // something process multiple componants at once
+                               // wasteful to do one at a time probably
+          V &global_coeffs, bool force_thread_per_dof = false) {
+
+    this->dh_global_coeffs.realloc_no_copy(global_coeffs.size());
+    fill_device_buffer_and_wait(this->dh_global_coeffs.d_buffer.ptr, U(0.0),
+                                global_coeffs.size(), this->sycl_target->queue);
+
+    if (this->mesh->get_ndim() == 2) {
+      if (this->sycl_target->queue.get_device().is_gpu() ||
+          force_thread_per_dof) {
+        project_inner<Project::eQuad<Project::ThreadPerDof>, U>(particle_group,
+                                                                sym, component)
+            .wait();
+        project_inner<Project::eTriangle<Project::ThreadPerDof>, U>(
+            particle_group, sym, component)
+            .wait();
+      } else {
+        project_inner<Project::eQuad<Project::ThreadPerCell>, U>(particle_group,
+                                                                 sym, component)
+            .wait();
+
+        project_inner<Project::eTriangle<Project::ThreadPerCell>, U>(
+            particle_group, sym, component)
+            .wait();
+      }
+    } else {
+      if (this->sycl_target->queue.get_device().is_gpu() ||
+          force_thread_per_dof) {
+        project_inner<Project::eHex<Project::ThreadPerDof>, U>(particle_group,
+                                                               sym, component)
+            .wait();
+        project_inner<Project::ePrism<Project::ThreadPerDof>, U>(particle_group,
+                                                                 sym, component)
+            .wait();
+        project_inner<Project::eTet<Project::ThreadPerDof>, U>(particle_group,
+                                                               sym, component)
+            .wait();
+        project_inner<Project::ePyramid<Project::ThreadPerDof>, U>(
+            particle_group, sym, component)
+            .wait();
+      } else {
+        project_inner<Project::eHex<Project::ThreadPerCell>, U>(particle_group,
+                                                                sym, component)
+            .wait();
+        project_inner<Project::ePrism<Project::ThreadPerCell>, U>(
+            particle_group, sym, component)
+            .wait();
+        project_inner<Project::eTet<Project::ThreadPerCell>, U>(particle_group,
+                                                                sym, component)
+            .wait();
+        project_inner<Project::ePyramid<Project::ThreadPerCell>, U>(
+            particle_group, sym, component)
+            .wait();
+      }
+    }
+
+    // copyback
+    this->sycl_target->queue
+        .memcpy(global_coeffs.begin(), this->dh_global_coeffs.d_buffer.ptr,
+                global_coeffs.size() * sizeof(U))
+        .wait();
+  }
+};
+} // namespace NESO

--- a/include/nektar_interface/function_projection.hpp
+++ b/include/nektar_interface/function_projection.hpp
@@ -11,9 +11,12 @@
 #include <neso_particles.hpp>
 
 #include "basis_reference.hpp"
+#ifdef NESO_USE_NEW_PROJECTION
+#include "function_basis_projection_alt.hpp"
+#else
 #include "function_basis_projection.hpp"
+#endif
 #include "particle_interface.hpp"
-
 using namespace Nektar::MultiRegions;
 using namespace Nektar::LibUtilities;
 using namespace NESO::Particles;

--- a/include/nektar_interface/projection/algorithm_types.hpp
+++ b/include/nektar_interface/projection/algorithm_types.hpp
@@ -1,0 +1,269 @@
+#pragma once
+
+#include "constants.hpp"
+#include "device_data.hpp"
+#include "shapes.hpp"
+#include <sycl/sycl.hpp>
+#include <limits>
+#include <optional>
+
+#define ROUND_UP_TO_MULTIPLE(MULTIPLE, X)                                      \
+  (MULTIPLE) * ((((X) - 1) / (MULTIPLE)) + 1)
+#define ROUND_DOWN_TO_MULTIPLE(MULTIPLE, X) (MULTIPLE) * ((X) / (MULTIPLE))
+
+namespace NESO::Project {
+namespace Private {
+template <int nmode, typename Shape>
+static inline uint64_t total_local_slots() {
+  if constexpr (Shape::dim == 2) {
+    return Shape::template local_mem_size<nmode, 0>(1) +
+           Shape::template local_mem_size<nmode, 1>(1);
+  } else if constexpr (Shape::dim == 3) {
+    return Shape::template local_mem_size<nmode, 0>(1) +
+           Shape::template local_mem_size<nmode, 1>(1) +
+           Shape::template local_mem_size<nmode, 2>(1);
+  } else {
+    static_assert(false, "Only support 2 and 3 dimensional cell types");
+    // unreachable
+    return -1;
+  }
+}
+
+template <int nmode, typename T, typename Shape>
+static inline uint64_t calc_max_local_size(sycl::queue &queue,
+                                           int preferred_block_size) {
+  auto dev = queue.get_device();
+  // We subtract 1024 because cuda reserves that much per SM for itself
+  // Don't know if there is some "sycl" way to get this info
+  // TODO: Find the corresponding number for AMD and Intel
+  uint64_t local_mem_max =
+      (dev.get_info<sycl::info::device::local_mem_size>() - 1024) /
+      sizeof(T);
+  uint64_t local_required = total_local_slots<nmode, Shape>();
+  if (local_required * (preferred_block_size + 1) < local_mem_max) {
+    return preferred_block_size;
+  }
+  // check it's possible to find anything
+  // Make sure a != 0 in next step
+  if (local_required > local_mem_max) {
+    return 0;
+  }
+  // Need (a + 1) * local_required <= local_mem_max
+  //      a <= local_mem_max/local_requred - 1
+  uint64_t a = (local_mem_max / local_required) - 1;
+  // not sure about the sub_group_sizes thing but is the closest I can find
+  size_t min_sub_group_size =
+      dev.is_gpu()
+          ? (dev.get_info<sycl::info::device::sub_group_sizes>()[0])
+          : 1;
+  // Will return 0 if can't find something that is a multiple of
+  //(min_sub_group_size + 1) that fits
+  return ROUND_DOWN_TO_MULTIPLE(min_sub_group_size, a);
+}
+} // namespace Private
+
+struct ThreadPerCell {
+  template <int nmode, typename T, int alpha, int beta, typename Shape>
+  std::optional<sycl::event> static inline project(DeviceData<T> &data,
+                                                       int componant,
+                                                       sycl::queue &queue) {
+    sycl::range<1> range{static_cast<size_t>(data.ncells)};
+    if constexpr (Shape::dim == 2) {
+      return queue.submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<>(range, [=](sycl::id<1> idx) {
+          auto cellx = data.cell_ids[idx];
+          auto npart = data.par_per_cell[cellx];
+
+          if (npart == 0)
+            return;
+
+          auto cell_dof = &data.dofs[data.dof_offsets[cellx]];
+          for (int part = 0; part < npart; ++part) {
+            auto xi0 = data.positions[cellx][0][part];
+            auto xi1 = data.positions[cellx][1][part];
+            T eta0, eta1;
+            Shape::template loc_coord_to_loc_collapsed<T>(xi0, xi1, eta0, eta1);
+            auto qoi = data.input[cellx][componant][part];
+            Shape::template project_one_particle<nmode, T, alpha, beta>(
+                eta0, eta1, qoi, cell_dof);
+          }
+        });
+      });
+    } else {
+      return queue.submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<>(range, [=](sycl::id<1> idx) {
+          auto cellx = data.cell_ids[idx];
+          auto npart = data.par_per_cell[cellx];
+
+          if (npart == 0)
+            return;
+
+          auto cell_dof = &data.dofs[data.dof_offsets[cellx]];
+          for (int part = 0; part < npart; ++part) {
+            auto xi0 = data.positions[cellx][0][part];
+            auto xi1 = data.positions[cellx][1][part];
+            auto xi2 = data.positions[cellx][2][part];
+            T eta0, eta1, eta2;
+            Shape::template loc_coord_to_loc_collapsed<T>(xi0, xi1, xi2, eta0,
+                                                          eta1, eta2);
+            auto qoi = data.input[cellx][componant][part];
+            Shape::template project_one_particle<nmode, T, alpha, beta>(
+                eta0, eta1, eta2, qoi, cell_dof);
+          }
+        });
+      });
+    }
+  }
+};
+
+// Untested on Microsoft
+// c++20 has a solution for this std::source_location::function_name
+#ifdef _MSC_VER
+#define PRETTY_FUNCTION __FUNCSIG__
+#else
+#define PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+struct ThreadPerDof {
+
+  template <int nmode, typename T, int alpha, int beta, typename Shape>
+  std::optional<sycl::event> static inline project(DeviceData<T> &data,
+                                                       int componant,
+                                                       sycl::queue &queue) {
+
+    // TODO: What to do when local_size comes back as zero
+    // 1. Theoretically can use fewer than the warp size for the block size
+    //    just be slow
+    // 2. Crash always
+    // 3. Crash in debug/warn in release <--- doing this for now, crashing will
+    //    compilcate the benchmarking in release
+    auto local_size = Private::calc_max_local_size<nmode, T, Shape>(
+        queue, Constants::preferred_block_size);
+    if (local_size == 0) {
+      fprintf(stderr,
+              "%s: This kernel uses too much local(shared) memory for your "
+              "device\n",
+              PRETTY_FUNCTION);
+      // Crash in debug version
+      assert(false);
+      // Just return empty optional in release mode
+      // Doing this so the benchmarks can run without crashing
+      // TODO: This needs a better solution I could raise an exception (blurg)
+      // or make it return std::option (more rusty)
+      return {};
+    }
+
+    std::size_t outer_size = ROUND_UP_TO_MULTIPLE(local_size, data.nrow_max);
+
+    sycl::nd_range<2> range(sycl::range<2>(data.ncells, outer_size),
+                                sycl::range<2>(1, local_size));
+    // in practice won't overflow a int
+    assert((local_size + 1) < std::numeric_limits<int>::max());
+    int stride = (int)local_size + 1;
+    if constexpr (Shape::dim == 2) {
+      return queue.submit([&](sycl::handler &cgh) {
+        sycl::local_accessor<T> local_mem0{
+            Shape::template local_mem_size<nmode, 0>(stride), cgh};
+        sycl::local_accessor<T> local_mem1{
+            Shape::template local_mem_size<nmode, 1>(stride), cgh};
+
+        cgh.parallel_for<>(range, [=](sycl::nd_item<2> idx) {
+          const int cellx = data.cell_ids[idx.get_global_id(0)];
+          long npart = data.par_per_cell[cellx];
+          if (npart == 0)
+            return;
+          int idx_local = idx.get_local_id(1);
+          const int layerx = idx.get_global_id(1);
+
+          if (layerx < npart) {
+            auto xi0 = data.positions[cellx][0][layerx];
+            auto xi1 = data.positions[cellx][1][layerx];
+            T eta0, eta1;
+            Shape::template loc_coord_to_loc_collapsed<T>(xi0, xi1, eta0, eta1);
+            Shape::template fill_local_mem<nmode, T, alpha, beta>(
+                eta0, eta1, data.input[cellx][componant][layerx],
+                &local_mem0[idx_local], &local_mem1[idx_local], stride);
+          }
+
+          idx.barrier(sycl::access::fence_space::local_space);
+
+          auto ndof = Shape::template get_ndof<nmode>();
+          long nthd = idx.get_local_range(1);
+          const auto cell_dof = &data.dofs[data.dof_offsets[cellx]];
+          auto count =
+              std::min(nthd, std::max(long{0}, npart - layerx + idx_local));
+          auto mode0 = &local_mem0[0];
+          auto mode1 = &local_mem1[0];
+
+          while (idx_local < ndof) {
+            auto temp = Shape::template reduce_dof<nmode, T>(
+                idx_local, count, mode0, mode1, stride);
+            sycl::atomic_ref<T, sycl::memory_order::relaxed,
+                                 sycl::memory_scope::device>
+                coeff_atomic_ref(cell_dof[idx_local]);
+            coeff_atomic_ref.fetch_add(temp);
+            idx_local += nthd;
+          }
+        });
+      });
+    } else {
+      return queue.submit([&](sycl::handler &cgh) {
+        sycl::local_accessor<T> local_mem0{
+            Shape::template local_mem_size<nmode, 0>(stride), cgh};
+        sycl::local_accessor<T> local_mem1{
+            Shape::template local_mem_size<nmode, 1>(stride), cgh};
+        sycl::local_accessor<T> local_mem2{
+            Shape::template local_mem_size<nmode, 2>(stride), cgh};
+
+        cgh.parallel_for<>(range, [=](sycl::nd_item<2> idx) {
+          const int cellx = data.cell_ids[idx.get_global_id(0)];
+          long npart = data.par_per_cell[cellx];
+
+          if (npart == 0)
+            return;
+
+          int idx_local = idx.get_local_id(1);
+          const int layerx = idx.get_global_id(1);
+
+          if (layerx < npart) {
+            auto xi0 = data.positions[cellx][0][layerx];
+            auto xi1 = data.positions[cellx][1][layerx];
+            auto xi2 = data.positions[cellx][2][layerx];
+            T eta0, eta1, eta2;
+            Shape::template loc_coord_to_loc_collapsed<T>(xi0, xi1, xi2, eta0,
+                                                          eta1, eta2);
+            Shape::template fill_local_mem<nmode, T, alpha, beta>(
+                eta0, eta1, eta2, data.input[cellx][componant][layerx],
+                &local_mem0[idx_local], &local_mem1[idx_local],
+                &local_mem2[idx_local], stride);
+          }
+
+          idx.barrier(sycl::access::fence_space::local_space);
+
+          auto ndof = Shape::template get_ndof<nmode>();
+          long nthd = idx.get_local_range(1);
+          const auto cell_dof = &data.dofs[data.dof_offsets[cellx]];
+          auto count =
+              std::min(nthd, std::max(long{0}, npart - layerx + idx_local));
+          auto mode0 = &local_mem0[0];
+          auto mode1 = &local_mem1[0];
+          auto mode2 = &local_mem2[0];
+
+          while (idx_local < ndof) {
+            auto temp = Shape::template reduce_dof<nmode, T>(
+                idx_local, count, mode0, mode1, mode2, stride);
+            sycl::atomic_ref<T, sycl::memory_order::relaxed,
+                                 sycl::memory_scope::device>
+                coeff_atomic_ref(cell_dof[idx_local]);
+            coeff_atomic_ref.fetch_add(temp);
+            idx_local += nthd;
+          }
+        });
+      });
+    }
+  }
+};
+#undef ROUND_UP_TO_MULTIPLE
+#undef ROUND_DOWN_TO_MULTIPLE
+#undef PRETTY_FUNCTION
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/auto_switch.hpp
+++ b/include/nektar_interface/projection/auto_switch.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#define AUTO_SWITCH_one_case(n, return_val, func, args, ...)                   \
+  case (n): {                                                                  \
+    return_val = func<n, __VA_ARGS__> args;                                    \
+    break;                                                                     \
+  }
+
+#ifndef AUTO_SWITCH_max_nmode
+#define AUTO_SWITCH_max_nmode 8
+#endif
+#include <cassert>
+#include <cstdio>
+
+#define AUTO_SWITCH_one_case_1(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case(1, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_2(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_1(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(2, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_3(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_2(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(3, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_4(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_3(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(4, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_5(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_4(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(5, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_6(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_5(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(6, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_7(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_6(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(7, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_8(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_7(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(8, return_val, func, args, __VA_ARGS__)
+#if 0
+#define AUTO_SWITCH_one_case_9(return_val, func, args, ...)                    \
+  AUTO_SWITCH_one_case_8(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(9, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_10(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_9(return_val, func, args, __VA_ARGS__)                  \
+      AUTO_SWITCH_one_case(10, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_11(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_10(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(11, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_12(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_11(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(12, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_13(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_12(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(13, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_14(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_13(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(14, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_15(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_14(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(15, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_16(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_15(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(16, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_17(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_16(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(17, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_18(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_17(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(18, return_val, func, args, __VA_ARGS__)
+#define AUTO_SWITCH_one_case_19(return_val, func, args, ...)                   \
+  AUTO_SWITCH_one_case_18(return_val, func, args, __VA_ARGS__)                 \
+      AUTO_SWITCH_one_case(19, return_val, func, args, __VA_ARGS__)
+#endif
+#define AUTO_SWITCH_internal(n, var, return_val, func, args, ...)              \
+  switch (var) {                                                               \
+    AUTO_SWITCH_one_case_##n(return_val, func, args, __VA_ARGS__);             \
+  default: {                                                                   \
+    fprintf(stderr, "Not supported nmode == %d\n", var);                       \
+    assert(false);                                                             \
+  }                                                                            \
+  };
+
+#define AUTO_SWITCH_internal_(n, var, return_val, func, args, ...)             \
+  AUTO_SWITCH_internal(n, var, return_val, func, args, __VA_ARGS__)
+
+#define FUNCTION_ARGS(...) (__VA_ARGS__)
+#define AUTO_SWITCH(var, return_val, func, args, ...)                          \
+  AUTO_SWITCH_internal_(AUTO_SWITCH_max_nmode, var, return_val, func, args,    \
+                        __VA_ARGS__)
+
+/*
+ * USAGE:
+ *
+ * requires some templated function
+ * where we want to do a switch on the first argument + an arbitery number of
+ * others (actually has to be at least one other or it will break, but if its
+ * the only argument then the whole thing can be easier)
+ *
+ * <int N,M,P,Q,...>
+ * fun(a,b,c,f,...) {...}
+ *
+ * then cat create a switch case statemnt up
+ * to AUTO_SWITCH_max_nmode on a variable
+ * n like this:
+ *
+ * AUTO_SWITCH(n,return_val,func,FUNCTION_ARGS(a,b,c,f,...),M,N,P,Q);
+ *
+ * this will expande to something like
+ * switch(n) {
+ * case 1:
+ *   return_val = func<1,M,N,P,Q>(a,b,c,d,e,f,..);
+ *   break;
+ * case 2:
+ *   return_val = func<2,M,N,P,Q>(a,b,c,d,e,f,..);
+ *   break;
+ * etc etc
+ * case 19:
+ *   return_val = func<19,M,N,P,Q>(a,b,c,d,e,f,..);
+ *   break;*
+ * default:
+ *   assert("n is too big")*
+ * }
+ *
+ * NOTE: We have to shove the function arguments in the FUNCTION_ARGS macro
+ * or we can just use (). it makes no difference i.e.
+ *
+ * AUTO_SWITCH(n,func,(a,b,c,f,...),M,N,P,Q);
+ *
+ * is equivilent to the above, but we need the parenthases or the everything
+ * gets swollowed up by the __VA_ARGS__ at the end
+ *
+ */

--- a/include/nektar_interface/projection/basis/basis.hpp
+++ b/include/nektar_interface/projection/basis/basis.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include <cmath>
+#include <cstdint>
+
+#include "../unroll.hpp"
+#include "jacobi.hpp"
+#include "power.hpp"
+#include "static_for.hpp"
+namespace NESO::Basis {
+namespace Private {
+template <int64_t P, int64_t Q> constexpr int64_t max() {
+  return P > Q ? P : Q;
+}
+} // namespace Private
+template <typename T, int32_t N, int32_t alpha, int32_t beta>
+inline double NESO_ALWAYS_INLINE eModA(T z) {
+  if constexpr (N == 0)
+    return 0.5 * (1.0 - z);
+  else if constexpr (N == 1)
+    return 0.5 * (1.0 + z);
+  else
+    return 0.25 * (1.0 - z) * (1.0 + z) *
+           Private::jacobi<T, N - 2, alpha, beta>(z);
+}
+
+template <typename T, int32_t N, int32_t alpha, int32_t beta>
+inline auto NESO_ALWAYS_INLINE eModA(T z, T *output, int32_t stride) {
+  const T b0 = 0.5 * (1.0 - z);
+  const T b1 = 0.5 * (1.0 + z);
+  output[0] = b0;
+  output[stride] = b1;
+  Private::static_for<N - 2>([&](auto idx) {
+    assert((2 + idx.value) < N);
+    output[(2 + idx.value) * stride] =
+        b0 * b1 * Private::jacobi<T, idx.value, alpha, beta>(z);
+  });
+}
+
+template <int32_t N> constexpr inline auto NESO_ALWAYS_INLINE eModA_len() {
+  return N;
+}
+
+template <typename T, int32_t N, int32_t alpha, int32_t beta>
+inline auto NESO_ALWAYS_INLINE eModB(T z, T *output, int32_t stride) {
+  T b0 = 1.0;
+  const T b1 = 0.5 * (1.0 + z);
+  Private::static_for<N>([&](auto p) {
+    Private::static_for<N - p.value>([&](auto q) {
+      if constexpr (p.value == 0) {
+        *output = eModA<T, q.value, alpha, beta>(z);
+        output += stride;
+      } else if constexpr (q.value == 0) {
+        *output = b0;
+        output += stride;
+      } else {
+        *output =
+            b0 * b1 * Private::jacobi<T, q.value - 1, 2 * p.value - 1, 1>(z);
+        output += stride;
+      }
+    });
+    b0 *= 0.5 * (1.0 - z);
+  });
+}
+
+template <typename T, int32_t p, int32_t q, int32_t alpha, int32_t beta>
+inline auto NESO_ALWAYS_INLINE eModB(T z) {
+  if constexpr (p == 0) {
+    return eModA<T, q, alpha, beta>(z);
+  } else if constexpr (q == 0) {
+    T b0 = Private::power<T, p>::_(0.5 * (1.0 - z));
+    return b0;
+  } else {
+    T b0 = Private::power<T, p>::_(0.5 * (1.0 - z));
+    T const b1 = 0.5 * (1.0 + z);
+    return b1 * b0 * Private::jacobi<T, q - 1, 2 * p - 1, 1>(z);
+  }
+}
+
+template <int32_t N> constexpr inline auto NESO_ALWAYS_INLINE eModB_len() {
+  return N * (N + 1) >> 1;
+}
+
+template <typename T, int32_t N, int32_t alpha, int32_t beta>
+inline auto NESO_ALWAYS_INLINE eModC(T z, T *output, int32_t stride) {
+  Private::static_for<N>([&](auto p) {
+    Private::static_for<N - p.value>([&](auto q) {
+      Private::static_for<N - p.value - q.value>([&](auto r) {
+        *output = eModB<T, p.value + q.value, r.value, alpha, beta>(z);
+        output += stride;
+      });
+    });
+  });
+}
+
+// TODO double check this is correct sum of N triangle numbers
+template <int32_t N> inline constexpr auto NESO_ALWAYS_INLINE eModC_len() {
+  return N * (N + 1) * (N + 2) / 6;
+}
+
+template <typename T, int32_t N, int32_t alpha, int32_t beta>
+inline auto NESO_ALWAYS_INLINE eModPyrC(T z, T *output, int32_t stride) {
+  const T b0 = 0.5 * (1.0 - z);
+  const T b1 = 0.5 * (1.0 + z);
+  Private::static_for<N>([&](auto p) {
+    Private::static_for<N>([&](auto q) {
+      constexpr auto max = Private::max<p.value, q.value>();
+      Private::static_for<N - max>([&](auto r) {
+        if constexpr (p.value == 0)
+          *output = eModB<T, q.value, r.value, alpha, beta>(z);
+        else if constexpr (p.value == 1) {
+          auto constexpr m = q.value == 0 ? 1 : q.value;
+          *output = eModB<T, m, r.value, alpha, beta>(z);
+        } else if constexpr (q.value < 2) {
+          *output = eModB<T, p.value, r.value, alpha, beta>(z);
+        } else if constexpr (r.value == 0) {
+          *output = Private::power<T, p.value + q.value - 2>::_(b0);
+        } else {
+          *output =
+              b1 * Private::power<T, p.value + q.value - 2>::_(b0) *
+              Private::jacobi<T, r.value - 1, 2 * p.value + 2 * q.value - 3, 1>(
+                  z);
+        }
+        output += stride;
+      });
+    });
+  });
+}
+
+// Sum of squares
+template <int32_t N> inline constexpr auto NESO_ALWAYS_INLINE eModPyrC_len() {
+  return N * (N + 1) * (2 * N + 1) / 6;
+}
+
+} // namespace NESO::Basis

--- a/include/nektar_interface/projection/basis/jacobi.hpp
+++ b/include/nektar_interface/projection/basis/jacobi.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <cmath>
+#include <cstdint>
+
+namespace NESO::Basis::Private {
+template <int64_t n> inline int64_t pochhammer(const int64_t m) {
+  return (m + (n - 1)) * pochhammer<n - 1>(m);
+}
+template <> inline int64_t pochhammer<0>([[maybe_unused]] const int64_t m) {
+  return 1;
+}
+
+template <typename T, int64_t p, int64_t alpha, int64_t beta>
+inline auto __attribute__((always_inline)) jacobi([[maybe_unused]] T const z) {
+  static_assert(p >= 0, "p must be >= 0");
+  if constexpr (p == 0)
+    return 1.0;
+  else if constexpr (p == 1)
+    return T(0.5 * (2.0 * T(alpha + 1) + T(alpha + beta + 2) * (z - 1.0)));
+  else if constexpr (p == 2)
+    return T(0.125) *
+           (T(4.0 * (alpha + 1.0) * (alpha + 2.0)) +
+            T(4.0 * (alpha + beta + 3.0) * (alpha + 2.0)) * (z - (1.0)) +
+            T((alpha + beta + 3.0)) * T((alpha + beta + 4.0)) * (z - (1.0)) *
+                (z - (1.0)));
+  else {
+    auto n = p - 1;
+    auto pn = jacobi<T, p - 1, alpha, beta>(z);
+    auto pnm1 = jacobi<T, p - 2, alpha, beta>(z);
+    auto coeff_pnp1 = T(2.0 * (n + 1.0) // 6
+                        * (n + alpha + beta + 1.0) * (2.0 * n + alpha + beta));
+    auto coeff_pn =
+        T((2.0 * n + alpha + beta + 1.0) * (alpha * alpha - beta * beta)) +
+        T(pochhammer<3>(2 * (p - 1) + alpha + beta)) * z;
+    auto coeff_pnm1 =
+        T(-2.0 * (n + alpha) * (n + beta) * (2.0 * n + alpha + beta + 2.0));
+    return T((1.0 / coeff_pnp1) * (coeff_pn * pn + coeff_pnm1 * pnm1));
+  }
+}
+} // namespace NESO::Basis::Private

--- a/include/nektar_interface/projection/basis/power.hpp
+++ b/include/nektar_interface/projection/basis/power.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+// Templated implimentation
+// of power function with addition-chain exponentiation
+// https://en.wikipedia.org/wiki/Addition-chain_exponentiation
+// Usage:
+//       a^N = power<T,N>::_(a)
+// have to put things in static functions inside structs
+// to get around no partial specialisation of functions
+// hence the funky syntax
+
+namespace NESO::Basis::Private {
+
+// base case uses exponentiation by squaring
+template <typename T, int N> struct power {
+  static constexpr T _(T a) {
+    static_assert(N >= 0, "N must be non-negative");
+    // let the specialisation cover the 0 case
+    if constexpr (N & 1) // is odd
+      return a * power<T, (N - 1) / 2>::_(a * a);
+    else
+      return power<T, N / 2>::_(a * a);
+  }
+};
+
+template <typename T> struct power<T, 0> {
+  static constexpr T _([[maybe_unused]] T a) { return T(1.0); }
+};
+
+template <typename T> struct power<T, 1> {
+  static constexpr T _(T a) { return a; }
+};
+
+template <typename T> struct power<T, 2> {
+  static constexpr T _(T a) { return a * a; }
+};
+
+template <typename T> struct power<T, 3> {
+  static constexpr T _(T a) { return a * a * a; }
+};
+
+template <typename T> struct power<T, 4> {
+  static constexpr T _(T a) { return power<T, 2>::_(a * a); }
+};
+
+template <typename T> struct power<T, 5> {
+  static constexpr T _(T a) { return power<T, 4>::_(a) * a; }
+};
+
+template <typename T> struct power<T, 6> {
+  static constexpr T _(T a) { return power<T, 3>::_(a * a); }
+};
+
+template <typename T> struct power<T, 7> {
+  static constexpr T _(T a) { return power<T, 6>::_(a) * a; }
+};
+
+template <typename T> struct power<T, 8> {
+  static constexpr T _(T a) {
+    a *= a;
+    a *= a;
+    return a * a;
+  }
+};
+
+template <typename T> struct power<T, 9> {
+  static constexpr T _(T a) {
+    a = power<T, 3>::_(a);
+    return power<T, 3>::_(a);
+  }
+};
+
+template <typename T> struct power<T, 10> {
+  static constexpr T _(T a) {
+    T b = a * a;
+    T d = b * b;
+    return d * d * b;
+  }
+};
+
+template <typename T> struct power<T, 11> {
+  static constexpr T _(T a) { return power<T, 10>::_(a) * a; }
+};
+
+template <typename T> struct power<T, 12> {
+  static constexpr T _(T a) {
+    T d = power<T, 4>::_(a);
+    return power<T, 3>::_(d);
+  }
+};
+
+template <typename T> struct power<T, 13> {
+  static constexpr T _(T a) { return power<T, 12>::_(a) * a; }
+};
+
+template <typename T> struct power<T, 14> {
+  static constexpr T _(T a) {
+    T b = a * a;
+    T d = b * b;
+    return power<T, 3>::_(d) * b;
+  }
+};
+
+template <typename T> struct power<T, 15> {
+  static constexpr T _(T a) {
+    T e = power<T, 5>::_(a);
+    return power<T, 3>::_(e);
+  }
+};
+
+template <typename T> struct power<T, 16> {
+  static constexpr T _(T a) {
+    T h = power<T, 8>::_(a);
+    return h * h;
+  }
+};
+
+} // namespace NESO::Basis::Private

--- a/include/nektar_interface/projection/basis/static_for.hpp
+++ b/include/nektar_interface/projection/basis/static_for.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstdint>
+#include <utility>
+namespace NESO::Basis::Private {
+// Static for loop found on stackoverflow
+// https://stackoverflow.com/questions/37602057/why-isnt-a-for-loop-a-compile-time-expression
+// Usage eg:
+// static_for<N>([&] (auto idx) { printf("%ld\n",idx.value);});
+template <int32_t N> struct Number {
+  static const constexpr auto value = N;
+};
+#if !defined(EXCLUDE_SYCL_HEADERS) && defined(__INTEL_LLVM_COMPILER)
+#include <sycl/sycl.hpp>
+#define NESO_SYCL_EXTERN extern SYCL_EXTERNAL
+#else
+#define NESO_SYCL_EXTERN
+#endif
+template <class F, int32_t... Is>
+NESO_SYCL_EXTERN inline void __attribute__((always_inline))
+static_for(F func, std::integer_sequence<int32_t, Is...>) {
+  (func(Number<Is>{}), ...);
+}
+
+template <int32_t N, typename F>
+NESO_SYCL_EXTERN inline void __attribute__((always_inline)) static_for(F func) {
+  if constexpr (N >= 0) {
+    static_for(func, std::make_integer_sequence<int32_t, N>());
+  }
+}
+} // namespace NESO::Basis::Private

--- a/include/nektar_interface/projection/constants.hpp
+++ b/include/nektar_interface/projection/constants.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+// Just somewhere to lump constants while developing
+// TODO think about this properly
+namespace NESO::Project::Constants {
+// Not all used.... yet
+constexpr int preferred_block_size = 128;
+constexpr int vector_width = 4;
+constexpr int beta = 1;
+constexpr int alpha = 1;
+constexpr int cpu_stride = 1;
+constexpr int gpu_warp_size = 32;
+constexpr double Tolerance = 1.0E-12;
+} // namespace NESO::Project::Constants

--- a/include/nektar_interface/projection/device_data.hpp
+++ b/include/nektar_interface/projection/device_data.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace NESO::Project {
+
+template <typename T> struct DeviceData {
+  T *dofs;
+  int *dof_offsets;
+  int ncells;
+  int nrow_max;
+  int *cell_ids;
+  int *par_per_cell;
+  T ***positions;
+  T ***input;
+  DeviceData(T *dofs_, int *dof_offsets_, int ncells_, int nrow_max_,
+             int *cell_ids_, int *par_per_cell_, T ***positions_, T ***input_)
+      : dofs{dofs_}, dof_offsets{dof_offsets_}, ncells{ncells_},
+        nrow_max{nrow_max_}, cell_ids{cell_ids_}, par_per_cell{par_per_cell_},
+        positions{positions_}, input{input_} {}
+};
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/hex.hpp
+++ b/include/nektar_interface/projection/hex.hpp
@@ -1,0 +1,107 @@
+#pragma once
+#include "basis/basis.hpp"
+#include "constants.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+
+namespace NESO::Project {
+
+struct ThreadPerCell;
+struct ThreadPerDof;
+
+namespace Private {
+struct eHexBase {
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::eHexahedron;
+  static constexpr int dim = 3;
+  template <typename T>
+  static inline NESO_ALWAYS_INLINE void
+  loc_coord_to_loc_collapsed(T const xi0, T const xi1, T const xi2, T &eta0,
+                             T &eta1, T &eta2) {
+    eta0 = xi0;
+    eta1 = xi1;
+    eta2 = xi2;
+  }
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return nmode * nmode * nmode;
+  }
+};
+} // namespace Private
+
+template <typename Algorithm> struct eHex : public Private::eHexBase {};
+
+template <> struct eHex<ThreadPerDof> : public Private::eHexBase {
+  using algorithm = ThreadPerDof;
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim >= 0 && dim < 3)
+      return stride * Basis::eModA_len<nmode>();
+    else
+      static_assert(true, "second templete parameter must be 0,1 or 2");
+    return -1;
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T eta2, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                T *NESO_RESTRICT local2,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, stride);
+    Basis::eModA<T, nmode, alpha, beta>(eta2, local2, stride);
+    for (int qx = 0; qx < nmode; ++qx) {
+      local1[qx * stride] *= qoi;
+    }
+  }
+
+  // TODO: Look at how this would work with vectors
+  // As is will not work at all
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            T *NESO_RESTRICT mode2,
+                                            int32_t stride) {
+    int i = idx_local / (nmode * nmode);
+    int j = (idx_local % (nmode * nmode)) / nmode;
+    int k = idx_local % nmode;
+    T dof = 0.0;
+    for (int d = 0; d < count; ++d) {
+      dof +=
+          mode2[i * stride + d] * mode1[j * stride + d] * mode0[k * stride + d];
+    }
+    return dof;
+  }
+};
+
+template <> struct eHex<ThreadPerCell> : public Private::eHexBase {
+  using algorithm = ThreadPerCell;
+
+  template <int nmode, typename T, int alpha, int beta>
+  static inline NESO_ALWAYS_INLINE void
+  project_one_particle(const T eta0, const T eta1, const T eta2, const T qoi,
+                       T *dofs) {
+    T local0[nmode];
+    T local1[nmode];
+    T local2[nmode];
+
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, 1);
+    Basis::eModA<T, nmode, alpha, beta>(eta2, local2, 1);
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      T temp0 = local2[i] * qoi;
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode; ++j) {
+        T temp1 = temp0 * local1[j];
+        NESO_UNROLL_LOOP
+        for (int k = 0; k < nmode; ++k) {
+          *dofs++ += temp1 * local0[k];
+        }
+      }
+    }
+  }
+};
+
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/prism.hpp
+++ b/include/nektar_interface/projection/prism.hpp
@@ -1,0 +1,153 @@
+#pragma once
+#include "basis/basis.hpp"
+#include "constants.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+#include "util.hpp"
+
+namespace NESO::Project {
+
+struct ThreadPerCell;
+struct ThreadPerDof;
+
+template <int nmode> constexpr auto look_up_table() {
+  std::array<int, nmode * Basis::eModB_len<nmode>()> arr;
+  int next = 0;
+  int offset = 0;
+  for (int i = 0; i < nmode; ++i) {
+    for (int j = 0; j < nmode; ++j) {
+      for (int k = 0; k < nmode - i; ++k) {
+        arr[next++] = i;
+      }
+    }
+  }
+  return arr;
+}
+
+namespace Private {
+struct ePrismBase {
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::ePrism;
+  static constexpr int dim = 3;
+  template <typename T>
+  static inline NESO_ALWAYS_INLINE void
+  loc_coord_to_loc_collapsed(T const xi0, T const xi1, T const xi2, T &eta0,
+                             T &eta1, T &eta2) {
+    eta1 = xi1;
+    eta2 = xi2;
+    eta0 = Util::Private::collapse_coords(xi0, xi2);
+  }
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return nmode * nmode * (nmode + 1) / 2;
+  }
+};
+} // namespace Private
+
+template <typename Algorithm> struct ePrism : public Private::ePrismBase {};
+
+template <> struct ePrism<ThreadPerDof> : public Private::ePrismBase {
+  using algorithm = ThreadPerDof;
+
+private:
+  // Getting to the i in i,j,k loop from the dof
+  // TODO: tested to nmode = (2 13) on CPU works ok
+  // TODO: test on GPU too - unit tests should cover it though
+  // if nmode == 3 then the loop turns out to need
+  //  0,1,2,3,4,5,6,7,8 -> 0
+  //  9,10,11,12,13,14 -> 1
+  //  15,16,17         -> 2
+  //  have to solve a quadratic equation
+  //  (dof + 1) = N * (2N - i)(i+1)/2 for i
+  template <int nmode>
+  static inline int NESO_ALWAYS_INLINE get_i_from_dof(int dof) {
+    double a = nmode;
+    double b = nmode * (1 - 2 * nmode);
+    double c = 2 * (dof + 1) - 2 * nmode * nmode;
+    double det = b * b - 4 * a * c;
+    return sycl::ceil((-b - sycl::sqrt(det)) / (2 * a));
+  }
+
+public:
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim == 0)
+      return stride * Basis::eModA_len<nmode>();
+    if constexpr (dim == 1)
+      return stride * Basis::eModA_len<nmode>();
+    else if constexpr (dim == 2) // is this right
+      return stride * Basis::eModB_len<nmode>();
+    else
+      static_assert(true, "dim templete parameter must be 0,1, or 2");
+    return -1;
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T eta2, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                T *NESO_RESTRICT local2,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, stride);
+    Basis::eModB<T, nmode, alpha, beta>(eta2, local2, stride);
+    for (int qx = 0; qx < Basis::eModA_len<nmode>(); ++qx) {
+      local1[qx * stride] *= qoi;
+    }
+  }
+
+  // TODO: Look at how this would work with vectors
+  // As is will not work at all
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            T *NESO_RESTRICT mode2,
+                                            int32_t stride) {
+    // TODO - this won't be constexpr need to refactor
+    int const i = get_i_from_dof<nmode>(idx_local);
+    auto const offset = nmode * (2 * nmode - i + 1) * i / 2;
+    int const j = (idx_local - offset) / (nmode - i);
+    int const k =
+        (idx_local - offset) % (nmode - i) + (2 * nmode - i + 1) * i / 2;
+    T dof = 0.0;
+    for (int d = 0; d < count; ++d) {
+      T correction = (i == 0 && k == 1) ? T(1.0) : mode0[i * stride + d];
+      dof += mode2[k * stride + d] * mode1[j * stride + d] * correction;
+    }
+    return dof;
+  }
+};
+
+template <> struct ePrism<ThreadPerCell> : public Private::ePrismBase {
+  using algorithm = ThreadPerCell;
+
+  template <int nmode, typename T, int alpha, int beta>
+  static inline NESO_ALWAYS_INLINE void
+  project_one_particle(const T eta0, const T eta1, const T eta2, const T qoi,
+                       T *dofs) {
+    T local0[Basis::eModA_len<nmode>()];
+    T local1[Basis::eModA_len<nmode>()];
+    T local2[Basis::eModB_len<nmode>()];
+
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, 1);
+    Basis::eModB<T, nmode, alpha, beta>(eta2, local2, 1);
+    int mode_r = 0;
+    // TODO: Check it isn't better to forget the correction in the loop then fix
+    // it at the end
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode; ++j) {
+        NESO_UNROLL_LOOP
+        for (int k = 0; k < nmode - i; ++k) {
+          T correction = (i == 0 && k == 1) ? 1.0 : local0[i];
+          *dofs++ += qoi * correction * local1[j] * local2[k + mode_r];
+        }
+      }
+      mode_r += nmode - i;
+    }
+  }
+};
+
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/pyramid.hpp
+++ b/include/nektar_interface/projection/pyramid.hpp
@@ -1,0 +1,154 @@
+#pragma once
+#include "basis/basis.hpp"
+#include "constants.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+#include "util.hpp"
+
+namespace NESO::Project {
+
+struct ThreadPerCell;
+struct ThreadPerDof;
+
+namespace Private {
+template <typename T> constexpr T inline NESO_ALWAYS_INLINE max(T i, T j) {
+  return (i > j) ? i : j;
+}
+struct ePyramidBase {
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::ePyramid;
+  static constexpr int dim = 3;
+  template <typename T>
+  static inline NESO_ALWAYS_INLINE void
+
+  loc_coord_to_loc_collapsed(T const xi0, T const xi1, T const xi2, T &eta0,
+                             T &eta1, T &eta2) {
+
+    // TODO: Doing too much work here now unless compiler is helping
+    // i.e. The beginning of the two calls do the same thing
+    // Look to refactor (see also the equivilent Tet function)
+
+    eta1 = Util::Private::collapse_coords(xi1, xi2);
+    eta0 = Util::Private::collapse_coords(xi0, xi2);
+    eta2 = xi2;
+  }
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return Basis::eModPyrC_len<nmode>();
+  }
+};
+} // namespace Private
+
+template <typename Algorithm> struct ePyramid : public Private::ePyramidBase {};
+
+template <> struct ePyramid<ThreadPerDof> : public Private::ePyramidBase {
+  using algorithm = ThreadPerDof;
+
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim == 0)
+      return Basis::eModA_len<nmode>() * stride;
+    else if constexpr (dim == 1)
+      return Basis::eModA_len<nmode>() * stride;
+    else if constexpr (dim == 2)
+      return Basis::eModPyrC_len<nmode>() * stride;
+    else {
+      static_assert(true, "second templete parameter must be 0,1 or 2");
+      return -1;
+    }
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T eta2, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                T *NESO_RESTRICT local2,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, stride);
+    Basis::eModPyrC<T, nmode, alpha, beta>(eta2, local2, stride);
+    for (int qx = 0; qx < Basis::eModPyrC_len<nmode>(); ++qx) {
+      local2[qx * stride] *= qoi;
+    }
+  }
+
+  // TODO: Need a benchmark for how to get the index, migth be bset to
+  //  load a look-up table for all the ones that need fiddeling
+  //  Could pack it save memory but is local_size smaller that the basis
+  //  arrays so so should be ok
+  // The inverse this time needs a cubic solving and I don't want to do that
+  //  option 1. look up table idx_local -> (i,j,k) (index < 256 even for
+  //  nmode==10 so can pack it into chars
+  //  option 2. construct a smaller table to work like a switch
+  //  e.g. { T_n, T_{n-1},...,1} > scan that
+  //  and search for index idx_local is less than
+  //  option 3. Newton solve if it works well enough in one step might be ok??
+  //  (Probably not) option 4: vvvvvv
+  struct index_pair {
+    int i, j;
+  };
+  // #warning "TEMP HACK TO GET IT WORKING NEED A GOOD WAY TO GET THE RIGHT
+  // INDEX"
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_index(int idx_local) {
+    int mode = 0;
+    struct index_pair pair = {-1, -1};
+    for (int i = 0; i < nmode; ++i)
+      for (int j = 0; j < nmode; ++j)
+        for (int k = 0; k < nmode - Private::max(i, j); ++k)
+          pair = (idx_local == mode++) ? (index_pair){i, j} : pair;
+    assert(pair.i != -1 && pair.j != -1);
+    return pair;
+  }
+  // TODO: Look at how this would work with vectors
+  // As is will not work at all
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            T *NESO_RESTRICT mode2,
+                                            int32_t stride) {
+    auto pair = get_index<nmode>(idx_local);
+    int i = pair.i;
+    int j = pair.j;
+    int k = idx_local;
+    T dof = 0.0;
+    for (int d = 0; d < count; ++d) {
+      T temp0 = (k == 1) ? 1.0 : mode0[i * stride + d] * mode1[j * stride + d];
+      dof += temp0 * mode2[k * stride + d];
+    }
+    return dof;
+  }
+};
+
+template <> struct ePyramid<ThreadPerCell> : public Private::ePyramidBase {
+  using algorithm = ThreadPerCell;
+
+  template <int nmode, typename T, int alpha, int beta>
+  static inline NESO_ALWAYS_INLINE void
+  project_one_particle(const T eta0, const T eta1, const T eta2, const T qoi,
+                       T *dofs) {
+    T local0[Basis::eModA_len<nmode>()];
+    T local1[Basis::eModA_len<nmode>()];
+    T local2[Basis::eModPyrC_len<nmode>()];
+
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, 1);
+    Basis::eModPyrC<T, nmode, alpha, beta>(eta2, local2, 1);
+    int mode = 0;
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      T temp0 = local0[i] * qoi;
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode; ++j) {
+        T temp1 = temp0 * local1[j];
+        NESO_UNROLL_LOOP
+        for (int k = 0; k < nmode - Private::max(i, j); ++k) {
+          temp1 = (mode == 1) ? qoi : temp1;
+          *dofs++ += temp1 * local2[mode];
+          mode++;
+        }
+      }
+    }
+  }
+};
+
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/quad.hpp
+++ b/include/nektar_interface/projection/quad.hpp
@@ -1,0 +1,93 @@
+#pragma once
+#include "basis/basis.hpp"
+#include "constants.hpp"
+#include "device_data.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+
+namespace NESO::Project {
+
+// Forward declare
+struct ThreadPerCell;
+struct ThreadPerDof;
+
+namespace Private {
+struct eQuadBase {
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::eQuadrilateral;
+  static constexpr int dim = 2;
+  template <typename T>
+  static void loc_coord_to_loc_collapsed(T xi0, T xi1, T &eta0, T &eta1) {
+    eta0 = xi0;
+    eta1 = xi1;
+  };
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return nmode * nmode;
+  }
+};
+} // namespace Private
+
+template <typename Algorithm> struct eQuad : public Private::eQuadBase {};
+
+template <> struct eQuad<ThreadPerCell> : public Private::eQuadBase {
+  using algorithm = ThreadPerCell;
+  template <int nmode, typename T, int alpha, int beta>
+  static inline NESO_ALWAYS_INLINE void
+  project_one_particle(const T eta0, const T eta1, const T qoi, T *dofs) {
+    T local0[Basis::eModA_len<nmode>()];
+    T local1[Basis::eModA_len<nmode>()];
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, 1);
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      double temp = local1[i] * qoi;
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode; ++j) {
+        dofs[j + nmode * i] += temp * local0[j];
+      }
+    }
+  }
+};
+
+template <> struct eQuad<ThreadPerDof> : public Private::eQuadBase {
+
+  using algorithm = ThreadPerDof;
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim == 0 || dim == 1)
+      return stride * Basis::eModA_len<nmode>();
+    else
+      static_assert(true, "second templete parameter must be 0 or 1");
+    return -1;
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModA<T, nmode, alpha, beta>(eta1, local1, stride);
+    for (int qx = 0; qx < nmode; ++qx) {
+      local1[qx * stride] *= qoi;
+    }
+  }
+
+  // TODO: Look at how this would work with vectors
+  // As is will not work at all
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            int32_t stride) {
+    int i = idx_local / nmode;
+    int j = idx_local % nmode;
+    T dof = 0.0;
+    for (int k = 0; k < count; ++k) {
+      dof += mode1[i * stride + k] * mode0[j * stride + k];
+    }
+    return dof;
+  }
+};
+
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/restrict.hpp
+++ b/include/nektar_interface/projection/restrict.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifndef NESO_RESTRICT
+// not sure cuda support __restrict
+#if defined(__CUDACC__)
+#define NESO_RESTRICT __restrict__
+#else
+// Everybody else seems fine with this
+#define NESO_RESTRICT __restrict
+#endif
+#endif

--- a/include/nektar_interface/projection/shapes.hpp
+++ b/include/nektar_interface/projection/shapes.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "hex.hpp"
+#include "prism.hpp"
+#include "pyramid.hpp"
+#include "quad.hpp"
+#include "tet.hpp"
+#include "tri.hpp"

--- a/include/nektar_interface/projection/tet.hpp
+++ b/include/nektar_interface/projection/tet.hpp
@@ -1,0 +1,160 @@
+#pragma once
+#include "basis/basis.hpp"
+#include "constants.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+#include "util.hpp"
+
+namespace NESO::Project {
+
+struct ThreadPerCell;
+struct ThreadPerDof;
+
+namespace Private {
+struct eTetBase {
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::eTetrahedron;
+  static constexpr int dim = 3;
+  template <typename T>
+  static inline NESO_ALWAYS_INLINE void
+  loc_coord_to_loc_collapsed(T const xi0, T const xi1, T const xi2, T &eta0,
+                             T &eta1, T &eta2) {
+
+    eta1 = Util::Private::collapse_coords(xi1, xi2);
+    // TODO: Leaky here re-factor into 2 functions
+    eta0 = Util::Private::collapse_coords(xi0, xi1 + xi2 + T(1.0));
+    // abstraction
+    eta2 = xi2;
+  }
+  // Doesn't need to be in the base class but useful for testing/benchmarking to
+  // be able to get this info for both algorithms
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return nmode * (nmode + 1) * (nmode + 2) / 6;
+  }
+};
+} // namespace Private
+
+template <typename Algorithm> struct eTet : public Private::eTetBase {};
+
+template <> struct eTet<ThreadPerDof> : public Private::eTetBase {
+  using algorithm = ThreadPerDof;
+
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim == 0)
+      return Basis::eModA_len<nmode>() * stride;
+    else if constexpr (dim == 1)
+      return Basis::eModB_len<nmode>() * stride;
+    else if constexpr (dim == 2)
+      return Basis::eModC_len<nmode>() * stride;
+    else {
+      static_assert(true, "second templete parameter must be 0,1 or 2");
+      return -1;
+    }
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T eta2, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                T *NESO_RESTRICT local2,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModB<T, nmode, alpha, beta>(eta1, local1, stride);
+    Basis::eModC<T, nmode, alpha, beta>(eta2, local2, stride);
+    for (int qx = 0; qx < Basis::eModC_len<nmode>(); ++qx) {
+      local2[qx * stride] *= qoi;
+    }
+  }
+
+  // TODO: Need a benchmark for how to get the index, migth be bset to
+  //  load a look-up table for all the ones that need fiddeling
+  //  Could pack it save memory but is local_size smaller that the basis
+  //  arrays so so should be ok
+  // The inverse this time needs a cubic solving and I don't want to do that
+  //  option 1. look up table idx_local -> (i,j,k) (index < 256 even for
+  //  nmode==10 so can pack it into chars
+  //  option 2. construct a smaller table to work like a switch
+  //  e.g. { T_n, T_{n-1},...,1} > scan that
+  //  and search for index idx_local is less than
+  //  option 3. Newton solve if it works well enough in one step might be ok??
+  //  (Probably not) option 4: vvvvvv
+  struct index_pair {
+    int i, j;
+  };
+  // #warning "TEMP HACK TO GET IT WORKING NEED A GOOD WAY TO GET THE RIGHT
+  // INDEX"
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_index(int idx_local) {
+    int mode = 0;
+    struct index_pair pair = {-1, -1};
+    for (int i = 0; i < nmode; ++i)
+      for (int j = 0; j < nmode - i; ++j)
+        for (int k = 0; k < nmode - i - j; ++k)
+          pair = (idx_local == mode++) ? (index_pair){i, j} : pair;
+    assert(pair.i != -1 && pair.j != -1);
+    return pair;
+  }
+  // TODO: Look at how this would work with vectors
+  // As is will not work at all
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            T *NESO_RESTRICT mode2,
+                                            int32_t stride) {
+    auto pair = get_index<nmode>(idx_local);
+    int i = pair.i;
+    int j = (i + 1) * (2 * nmode - i) / 2 - nmode + i + pair.j;
+    int k = idx_local;
+    T dof = 0.0;
+    for (int d = 0; d < count; ++d) {
+      T temp0 = (i == 0 && j == 1) ? 1.0 : mode0[i * stride + d];
+      T temp1 = (k == 1) ? 1.0 : temp0 * mode1[j * stride + d];
+      dof += temp1 * mode2[k * stride + d];
+    }
+    return dof;
+  }
+};
+
+template <> struct eTet<ThreadPerCell> : public Private::eTetBase {
+  using algorithm = ThreadPerCell;
+
+  template <int nmode, typename T, int alpha, int beta>
+  static inline NESO_ALWAYS_INLINE void
+  project_one_particle(const T eta0, const T eta1, const T eta2, const T qoi,
+                       T *dofs) {
+    T local0[Basis::eModA_len<nmode>()];
+    T local1[Basis::eModB_len<nmode>()];
+    T local2[Basis::eModC_len<nmode>()];
+
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModB<T, nmode, alpha, beta>(eta1, local1, 1);
+    Basis::eModC<T, nmode, alpha, beta>(eta2, local2, 1);
+    int mode = 0;
+    int mode_q = 0;
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      T temp0 = local0[i];
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode - i; ++j) {
+        T temp1 = local1[mode_q];
+        assert(mode_q == ((i + 1) * (2 * nmode - i) / 2 - nmode + i + j));
+        mode_q++;
+        NESO_UNROLL_LOOP
+        for (int k = 0; k < nmode - i - j; ++k) {
+          auto temp2 = local2[mode];
+          if (mode == 1)
+            *dofs++ += qoi * temp2;
+          else if (i == 0 && j == 1)
+            *dofs++ += qoi * temp1 * temp2;
+          else
+            *dofs++ += qoi * temp0 * temp1 * temp2;
+
+          mode++;
+        }
+      }
+    }
+  }
+};
+
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/tri.hpp
+++ b/include/nektar_interface/projection/tri.hpp
@@ -1,0 +1,120 @@
+#pragma once
+#include "algorithm_types.hpp"
+#include "basis/basis.hpp"
+#include "constants.hpp"
+// #include "device_data.hpp"
+#include "restrict.hpp"
+#include "unroll.hpp"
+#include "util.hpp"
+namespace NESO::Project {
+
+namespace Private {
+struct eTriangleBase {
+private:
+public:
+  static constexpr Nektar::LibUtilities::ShapeType shape_type =
+      Nektar::LibUtilities::eTriangle;
+  static constexpr int dim = 2;
+  template <typename T>
+  inline static void NESO_ALWAYS_INLINE
+  loc_coord_to_loc_collapsed(T const xi0, T const xi1, T &eta0, T &eta1) {
+    eta0 = Util::Private::collapse_coords(xi0, xi1);
+    eta1 = xi1;
+  }
+  template <int nmode> static auto NESO_ALWAYS_INLINE get_ndof() {
+    return nmode * (nmode + 1) / 2;
+  }
+};
+} // namespace Private
+
+template <typename Algorithm>
+struct eTriangle : public Private::eTriangleBase {};
+
+template <> struct eTriangle<ThreadPerDof> : public Private::eTriangleBase {
+  using algorithm = ThreadPerDof;
+
+private:
+  // solving for
+  //(nmode + 1 + (nmode +1 - dof))*(dof + 1)/2 = X;
+  // if nmode==4
+  // then
+  // 0,1,2,3,4 -> 0
+  // 5,6,7,8   -> 1
+  // 9,10,11   -> 2
+  // 12,13     -> 3
+  // 14        -> 4
+  // i.e. mapping from dof -> index in emodA array
+  template <int nmode>
+  static inline auto NESO_ALWAYS_INLINE get_i_from_dof(int dof) {
+    double a = double(1 - 2 * (nmode + 1));
+    double n = double(1 + 2 * (dof));
+    double tmp = -0.5 * (a + sycl::sqrt(a * a - 4 * n));
+    return int(sycl::floor(tmp));
+  }
+
+public:
+  template <int nmode, int dim>
+  static inline auto NESO_ALWAYS_INLINE local_mem_size(int32_t stride) {
+    if constexpr (dim == 0)
+      return stride * Basis::eModA_len<nmode>();
+    else if constexpr (dim == 1)
+      return stride * Basis::eModB_len<nmode>();
+    else
+      static_assert(true, "dim templete parameter must be 0 or 1");
+    return -1;
+  }
+
+  template <int nmode, typename T, int alpha, int beta>
+  static void NESO_ALWAYS_INLINE fill_local_mem(T eta0, T eta1, T qoi,
+                                                T *NESO_RESTRICT local0,
+                                                T *NESO_RESTRICT local1,
+                                                int32_t stride) {
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, stride);
+    Basis::eModB<T, nmode, alpha, beta>(eta1, local1, stride);
+    // The correction means the simplest thing is to multiply qoi by the
+    // longer array - the alternative is to store the qoi too(!?)
+    for (int qx = 0; qx < Basis::eModB_len<nmode>(); ++qx) {
+      local1[qx * stride] *= qoi;
+    }
+  }
+
+  template <int nmode, typename T>
+  static auto NESO_ALWAYS_INLINE reduce_dof(int idx_local, int count,
+                                            T *NESO_RESTRICT mode0,
+                                            T *NESO_RESTRICT mode1,
+                                            int32_t stride) {
+    int i = get_i_from_dof<nmode>(idx_local);
+    T dof = T{0.0};
+    for (int d = 0; d < count; ++d) {
+      // TODO: this correction might be bad or fine (for perf)
+      // need to check this
+      //(***)
+      T correction = (idx_local == 1) ? T(1.0) : mode0[i * stride + d];
+      dof += correction * mode1[idx_local * stride + d];
+    }
+    return dof;
+  }
+};
+
+template <> struct eTriangle<ThreadPerCell> : public Private::eTriangleBase {
+  using algorithm = ThreadPerCell;
+  template <int nmode, typename T, int alpha, int beta>
+  inline static void NESO_ALWAYS_INLINE
+  project_one_particle(T const eta0, T const eta1, T const qoi, T *dofs) {
+    T local0[Basis::eModA_len<nmode>()];
+    T local1[Basis::eModB_len<nmode>()];
+    Basis::eModA<T, nmode, alpha, beta>(eta0, local0, 1);
+    Basis::eModB<T, nmode, alpha, beta>(eta1, local1, 1);
+    int mode = 0;
+    NESO_UNROLL_LOOP
+    for (int i = 0; i < nmode; ++i) {
+      NESO_UNROLL_LOOP
+      for (int j = 0; j < nmode - i; ++j) {
+        T temp = (mode == 1) ? T{1.0} : local0[i];
+        dofs[mode] += temp * local1[mode] * qoi;
+        mode++;
+      }
+    }
+  }
+};
+} // namespace NESO::Project

--- a/include/nektar_interface/projection/unroll.hpp
+++ b/include/nektar_interface/projection/unroll.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#if defined(__clang__)
+#define NESO_UNROLL_LOOP _Pragma("clang loop unroll(full)")
+#elif defined(__GNUC__)
+#define NESO_UNROLL_LOOP _Pragma("GCC unroll 20")
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+#define NESO_ALWAYS_INLINE __attribute__((always_inline))
+#endif

--- a/include/nektar_interface/projection/util.hpp
+++ b/include/nektar_interface/projection/util.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "constants.hpp"
+#include "unroll.hpp"
+#include <sycl/sycl.hpp>
+namespace NESO::Project::Util::Private {
+
+template <typename T> inline auto NESO_ALWAYS_INLINE to_mask_vec(T a) {
+  return sycl::abs(a);
+}
+
+template <> inline auto NESO_ALWAYS_INLINE to_mask_vec<bool>(bool a) {
+  return static_cast<long>(a);
+}
+// cast from type U to type T
+// special case if U is a sycl vector to call convert function
+// ugly but can't think of anything better
+template <typename T, typename U, typename Q>
+inline auto NESO_ALWAYS_INLINE convert(U &in) {
+  if constexpr (std::is_same<U, sycl::vec<Q, 1>>::value ||
+                std::is_same<U, sycl::vec<Q, 2>>::value ||
+                std::is_same<U, sycl::vec<Q, 4>>::value ||
+                std::is_same<U, sycl::vec<Q, 8>>::value) {
+    return in.template convert<T>();
+  } else {
+    return static_cast<T>(in);
+  }
+}
+// Collapse one coord to point (I think)
+// A bit complicated to support support sycl vectors
+// also probably pre-optimised without checking if
+// branches where especially bad
+template <typename T>
+inline auto NESO_ALWAYS_INLINE collapse_coords(T const x, T const d) {
+  auto dprime = T(1.0) - d;
+  auto zeroTol = T(Constants::Tolerance);
+  auto mask_small =
+      Util::Private::to_mask_vec(sycl::fabs(dprime) < zeroTol);
+  zeroTol = sycl::copysign(zeroTol, dprime);
+  auto fmask =
+      Util::Private::convert<T, decltype(mask_small), long>(mask_small);
+  dprime = (T(1.0) - fmask) * dprime + fmask * zeroTol;
+  return T(2.0) * (T(1.0) + x) / dprime - T(1.0);
+}
+} // namespace NESO::Project::Util::Private

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,17 @@ set(UNIT_SRC_FILES
     ${UNIT_SRC}/nektar_interface/test_particle_mapping.cpp
     ${UNIT_SRC}/nektar_interface/test_utility_cartesian_mesh.cpp
     ${UNIT_SRC}/test_solver_callback.cpp)
+if (NESO_USE_NEW_PROJECTION)
+	list(APPEND UNIT_SRC_FILES 
+	${UNIT_SRC}/projection/test_quad.cpp
+	${UNIT_SRC}/projection/test_tri.cpp
+	${UNIT_SRC}/projection/test_hex.cpp
+	${UNIT_SRC}/projection/test_prism.cpp
+	${UNIT_SRC}/projection/test_tet.cpp
+	${UNIT_SRC}/projection/test_pyramid.cpp
+	)
+endif()
+
 
 check_file_list(${UNIT_SRC} cpp "${UNIT_SRC_FILES}" "")
 
@@ -86,6 +97,7 @@ add_executable(${UNIT_EXE} ${UNIT_SRC_FILES})
 target_link_libraries(${UNIT_EXE} PRIVATE ${NESO_LIBRARY_NAME} GTest::gtest)
 add_sycl_to_target(TARGET ${UNIT_EXE} SOURCES ${UNIT_SRC_FILES})
 gtest_add_tests(TARGET ${UNIT_EXE})
+
 
 # Build the integration test suite
 set(INTEGRATION_EXE integrationTests)

--- a/test/unit/projection/create_data.hpp
+++ b/test/unit/projection/create_data.hpp
@@ -1,0 +1,98 @@
+#include <sycl/sycl.hpp>
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/device_data.hpp>
+#include <utility>
+#include <vector>
+
+struct TestData2D {
+  int ndof;
+  double val;
+  double x, y;
+  TestData2D(int ndof_, double val_, double x_, double y_)
+      : ndof(ndof_), val(val_), x(x_), y(y_) {}
+  friend void PrintTo(TestData2D const &data, std::ostream *os) {
+    *os << data.ndof << ", " << data.val << ", (" << data.x << ", " << data.y
+        << ")";
+  }
+};
+
+struct TestData3D {
+  int ndof;
+  double val;
+  double x, y, z;
+  TestData3D(int ndof_, double val_, double x_, double y_, double z_ = 0.0)
+      : ndof(ndof_), val(val_), x(x_), y(y_), z{z_} {}
+  friend void PrintTo(TestData3D const &data, std::ostream *os) {
+    *os << data.ndof << ", " << data.val << ", (" << data.x << ", " << data.y
+        << ", " << data.z << ")";
+  }
+};
+
+static inline auto create_data(sycl::queue &Q, int N, double val, double x,
+                               double y, double z = double{0.0}) {
+  // Shove all the pointers in a vector so we can free them later
+  std::vector<void *> all_pointers;
+  double *dofs = sycl::malloc_device<double>(N, Q);
+  assert(dofs);
+  all_pointers.push_back((void *)dofs);
+  Q.fill(dofs, double{0.0}, N).wait_and_throw();
+
+  int *dof_offsets = sycl::malloc_device<int>(1, Q);
+  all_pointers.push_back((void *)dof_offsets);
+  assert(dof_offsets);
+  Q.fill(dof_offsets, 0, 1).wait_and_throw();
+
+  int *cell_ids = sycl::malloc_device<int>(1, Q);
+  all_pointers.push_back((void *)cell_ids);
+  assert(cell_ids);
+  Q.fill(cell_ids, 0, 1).wait_and_throw();
+
+  int *par_per_cell = sycl::malloc_device<int>(1, Q);
+  all_pointers.push_back((void *)par_per_cell);
+  assert(par_per_cell);
+  Q.fill(par_per_cell, 1, 1).wait_and_throw();
+
+  auto positions = sycl::malloc_device<double **>(1, Q);
+  all_pointers.push_back((void *)positions);
+  assert(positions);
+  auto temp0 = sycl::malloc_device<double *>(3, Q);
+  all_pointers.push_back((void *)temp0);
+  assert(temp0);
+  Q.fill(positions, temp0, 1).wait_and_throw();
+  double P[3] = {x, y, z};
+  double *pointP[3] = {sycl::malloc_device<double>(1, Q),
+                       sycl::malloc_device<double>(1, Q),
+                       sycl::malloc_device<double>(1, Q)};
+  assert(pointP[0] && pointP[1] && pointP[2]);
+  all_pointers.push_back((void *)pointP[0]);
+  all_pointers.push_back((void *)pointP[1]);
+  all_pointers.push_back((void *)pointP[2]);
+  Q.parallel_for<>(3, [=](sycl::id<1> id) {
+     positions[0][id] = pointP[id];
+     positions[0][id][0] = P[id];
+   }).wait_and_throw();
+
+  auto input = sycl::malloc_device<double **>(1, Q);
+  all_pointers.push_back((void *)input);
+  assert(input);
+  auto temp1 = sycl::malloc_device<double *>(1, Q);
+  assert(temp1);
+  all_pointers.push_back((void *)temp1);
+  auto temp2 = sycl::malloc_device<double>(1, Q);
+  assert(temp2);
+  all_pointers.push_back((void *)temp2);
+  Q.fill(input, temp1, 1).wait_and_throw();
+  Q.fill(temp1, temp2, 1).wait_and_throw();
+  Q.fill(temp2, val, 1).wait_and_throw();
+
+  return std::pair(NESO::Project::DeviceData<double>(dofs, dof_offsets, 1, 1,
+                                                     cell_ids, par_per_cell,
+                                                     positions, input),
+                   all_pointers);
+}
+
+static inline void free_data(sycl::queue &Q, std::vector<void *> &data) {
+  for (auto &p : data) {
+    sycl::free(p, Q);
+  }
+}

--- a/test/unit/projection/test_hex.cpp
+++ b/test/unit/projection/test_hex.cpp
@@ -1,0 +1,130 @@
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdHexExp.h>
+#include <StdRegions/StdMatrixKey.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <sycl/sycl.hpp>
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/hex.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectHexCell : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk{eModified_A, nmode, pk};
+    StdExpansion *Shape = new StdHexExp{bk, bk, bk};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eHex<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectHexCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectHexCell,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), // FAIL
+                      TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5), // FAIL
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1),
+                      TestData3D(8, 19, 0.5, -0.5) // FAIL
+                      ));
+
+class ProjectHexDof : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk{eModified_A, nmode, pk};
+    StdExpansion *Shape = new StdHexExp{bk, bk, bk};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eHex<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectHexDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectHexDof,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0, 0),
+                      TestData3D(4, 5.0, -1, -1, 0.3),
+                      TestData3D(3, 1.0, -0.5, 1, -0.3), // FAIL
+                      TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5), // FAIL
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1)));

--- a/test/unit/projection/test_prism.cpp
+++ b/test/unit/projection/test_prism.cpp
@@ -1,0 +1,127 @@
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdMatrixKey.h>
+#include <StdRegions/StdPrismExp.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <sycl/sycl.hpp>
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/hex.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectPrismCell : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    StdExpansion *Shape = new StdPrismExp{bk0, bk0, bk1};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::ePrism<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectPrismCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectPrismCell,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5),
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));
+
+class ProjectPrismDof : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    StdExpansion *Shape = new StdPrismExp{bk0, bk0, bk1};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::ePrism<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectPrismDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectPrismDof,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5),
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 1.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));

--- a/test/unit/projection/test_pyramid.cpp
+++ b/test/unit/projection/test_pyramid.cpp
@@ -1,0 +1,130 @@
+
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdMatrixKey.h>
+#include <StdRegions/StdPyrExp.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/pyramid.hpp>
+#include <sycl/sycl.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectPyramidCell : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModifiedPyr_C, nmode, pk};
+
+    StdExpansion *Shape = new StdPyrExp{bk0, bk0, bk1};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::ePyramid<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectPyramidCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectPyramidCell,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5),
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));
+
+class ProjectPyramidDof : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModifiedPyr_C, nmode, pk};
+
+    StdExpansion *Shape = new StdPyrExp{bk0, bk0, bk1};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::ePyramid<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectPyramidDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectPyramidDof,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5),
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));

--- a/test/unit/projection/test_quad.cpp
+++ b/test/unit/projection/test_quad.cpp
@@ -1,0 +1,118 @@
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdMatrixKey.h>
+#include <StdRegions/StdQuadExp.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/quad.hpp>
+#include <sycl/sycl.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectQuadCell : public ::testing::TestWithParam<TestData2D> {
+public:
+  double Integrate(TestData2D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk{eModified_A, nmode, pk};
+    StdExpansion *Shape = new StdQuadExp{bk, bk};
+
+    auto [data, pntrs] =
+        create_data(Q, nmode * nmode, test_data.val, test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1, eQuad<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectQuadCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(ProjectIntegralTests, ProjectQuadCell,
+                         ::testing::Values(TestData2D(5, 5.0, -1, -1),
+                                           TestData2D(3, 1.0, 0, 0),
+                                           TestData2D(6, 0.0, 1, -1),
+                                           TestData2D(7, 12899, 0.5, -0.5)));
+
+class ProjectQuadDof : public ::testing::TestWithParam<TestData2D> {
+public:
+  double Integrate(TestData2D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk{eModified_A, nmode, pk};
+    StdExpansion *Shape = new StdQuadExp{bk, bk};
+
+    auto [data, pntrs] =
+        create_data(Q, nmode * nmode, test_data.val, test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1, eQuad<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectQuadDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(ProjectIntegralTests, ProjectQuadDof,
+                         ::testing::Values(TestData2D(5, 5.0, -1, -1),
+                                           TestData2D(3, 1.0, 0, 0),
+                                           TestData2D(6, 0.0, 1, -1),
+                                           TestData2D(7, 12899, 0.5, -0.5)));

--- a/test/unit/projection/test_tet.cpp
+++ b/test/unit/projection/test_tet.cpp
@@ -1,0 +1,133 @@
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdMatrixKey.h>
+#include <StdRegions/StdTetExp.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <sycl/sycl.hpp>
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/tet.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectTetCell : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    BasisKey bk2{eModified_C, nmode, pk};
+    StdExpansion *Shape = new StdTetExp{bk0, bk1, bk2};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eTet<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectTetCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectTetCell,
+    ::testing::Values(TestData3D(3, 0.1, 0, 0), TestData3D(4, 5.0, -1, -1),
+                      TestData3D(3, 1.0, -0.5, 1), TestData3D(6, 0.1, 1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5),
+                      TestData3D(5, 5.0, -1, -1), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));
+
+#if 1
+
+class ProjectTetDof : public ::testing::TestWithParam<TestData3D> {
+public:
+  double Integrate(TestData3D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    BasisKey bk2{eModified_C, nmode, pk};
+    StdExpansion *Shape = new StdTetExp{bk0, bk1, bk2};
+
+    auto [data, pntrs] = create_data(Q, nmode * nmode * nmode, test_data.val,
+                                     test_data.x, test_data.y);
+
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eTet<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectTetDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectTetDof,
+    ::testing::Values(TestData3D(6, 0.1, 1, -1), TestData3D(3, 0.1, 0, 0),
+                      TestData3D(4, 5.0, -1, -1), TestData3D(3, 1.0, -0.5, 1),
+                      TestData3D(5, 5.0, -1, -1),
+                      TestData3D(7, 12899, 0.5, -0.5), TestData3D(3, 1.0, 0, 0),
+                      TestData3D(6, 0.0, 1, -1), TestData3D(8, 19, 0.5, -0.5)));
+
+#endif

--- a/test/unit/projection/test_tri.cpp
+++ b/test/unit/projection/test_tri.cpp
@@ -1,0 +1,128 @@
+#include <StdRegions/StdExpansion.h>
+#include <StdRegions/StdMatrixKey.h>
+#include <StdRegions/StdTriExp.h>
+
+#include <gtest/gtest.h>
+#include <nektar_interface/projection/algorithm_types.hpp>
+#include <nektar_interface/projection/device_data.hpp>
+
+#include <sycl/sycl.hpp>
+#include <nektar_interface/projection/auto_switch.hpp>
+#include <nektar_interface/projection/tri.hpp>
+
+#include "create_data.hpp"
+
+using namespace NESO::Project;
+using namespace Nektar;
+using namespace Nektar::LibUtilities;
+using namespace Nektar::StdRegions;
+
+class ProjectTriCell : public ::testing::TestWithParam<TestData2D> {
+public:
+  double Integrate(TestData2D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    StdExpansion *Shape = new StdTriExp{bk0, bk1};
+
+    auto [data, pntrs] =
+        create_data(Q, nmode * nmode, test_data.val, test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerCell::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eTriangle<ThreadPerCell>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectTriCell, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectTriCell,
+    ::testing::Values(TestData2D(3, 0.1, 0, 0), TestData2D(4, 5.0, -1, -1),
+                      TestData2D(3, 1.0, -0.5, 1), TestData2D(6, 0.1, 1, -1),
+                      TestData2D(7, 12899, 0.5, -0.5),
+                      TestData2D(5, 5.0, -1, -1), TestData2D(3, 1.0, 0, 0),
+                      TestData2D(6, 0.0, 1, -1), TestData2D(8, 19, 0.5, -0.5)));
+
+class ProjectTriDof : public ::testing::TestWithParam<TestData2D> {
+public:
+  double Integrate(TestData2D &test_data) {
+    sycl::queue Q{sycl::default_selector_v};
+    size_t const ndof = test_data.ndof;
+    size_t const nmode = ndof - 1;
+    PointsKey pk{ndof, eGaussLobattoLegendre};
+    BasisKey bk0{eModified_A, nmode, pk};
+    BasisKey bk1{eModified_B, nmode, pk};
+    StdExpansion *Shape = new StdTriExp{bk0, bk1};
+
+    auto [data, pntrs] =
+        create_data(Q, nmode * nmode, test_data.val, test_data.x, test_data.y);
+    std::optional<sycl::event> event;
+    AUTO_SWITCH(static_cast<int>(nmode), event, ThreadPerDof::template project,
+                FUNCTION_ARGS(data, 0, Q), double, 1, 1,
+                NESO::Project::eTriangle<ThreadPerDof>);
+    if (event) {
+      event.value().wait();
+    }
+    auto buffer = std::vector<double>(Shape->GetNcoeffs(), double(0.0));
+    Q.memcpy(buffer.data(), data.dofs, Shape->GetNcoeffs() * sizeof(double))
+        .wait();
+    Array<OneD, double> phi(Shape->GetNcoeffs(), buffer.data());
+    Array<OneD, double> coeffs(Shape->GetNcoeffs());
+
+    // Multiply by inverse mass matrix
+    StdMatrixKey masskey(eInvMass, Shape->DetShapeType(), *Shape);
+    DNekMatSharedPtr matsys = Shape->GetStdMatrix(masskey);
+    NekVector<NekDouble> coeffsVec(Shape->GetNcoeffs(), coeffs, eWrapper);
+    NekVector<NekDouble> phiVec(Shape->GetNcoeffs(), phi, eWrapper);
+    coeffsVec = (*matsys) * phiVec;
+
+    free_data(Q, pntrs);
+    // Transfrom to physical space
+    Array<OneD, double> phys(Shape->GetTotPoints());
+    Shape->BwdTrans(coeffs, phys);
+    return Shape->Integral(phys);
+  }
+};
+
+TEST_P(ProjectTriDof, IntegralIsRight) {
+  auto test_data = GetParam();
+  ASSERT_NEAR(test_data.val, Integrate(test_data), 1.0e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectIntegralTests, ProjectTriDof,
+    ::testing::Values(TestData2D(6, 0.1, 1, -1), TestData2D(4, 5.0, -1, -1),
+                      TestData2D(3, 1.0, -0.5, 1), TestData2D(3, 1.0, -0.5, 1),
+                      TestData2D(3, 1.0, -0.5, 1), TestData2D(3, 0.1, 0, 0),
+                      TestData2D(6, 0.1, 1, -1),
+                      TestData2D(7, 12899, 0.5, -0.5),
+                      TestData2D(5, 5.0, -1, -1), TestData2D(3, 1.0, 0, 0),
+                      TestData2D(6, 10, 0, -1)));


### PR DESCRIPTION
- Updated algorithms can be enabled with -DNESO_USE_NEW_PROJECTION=ON
- Added unit tests for each cell type, run with ./unitTests --gtest_filter=ProjectIntegralTests/*
- Benchmarks for performance testing enable with -DENABLE_NESO_BENCHMARKS=ON, uses google benchmark ./projection_bench -h for options, or ./projection_bench -- --help for google benchamark specific options

# Description
- Two versions of algorithm one for CPU and one for GPU - seem to be optimal for each but GPU alg may be better for high core count CPU if not enough cells  with particles to balance work across cells
- Also heavy (maybe too heavy) use of templates to calculate basis functions