### PR TITLE
Remove classic intel compiler in favour of oneapi@2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ according to the [official documentation](https://spack.readthedocs.io/en/latest
 apt update # For Ubuntu; other distros have their own commands
 apt install build-essential ca-certificates coreutils curl environment-modules gfortran git gpg lsb-release python3 python3-distutils python3-venv unzip zip
 
-git clone -c feature.manyFiles=true -b v0.19.0 https://github.com/spack/spack.git $HOME/.spack
-echo 'export SPACK_ROOT=$HOME/.spack' >> $HOME/.bashrc
+git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
+echo 'export SPACK_ROOT=$HOME/spack' >> $HOME/.bashrc
 echo 'source $SPACK_ROOT/share/spack/setup-env.sh' >> $HOME/.bashrc
-export SPACK_ROOT=$HOME/.spack
+export SPACK_ROOT=$HOME/spack
 source $SPACK_ROOT/share/spack/setup-env.sh
 ```
 
@@ -87,13 +87,6 @@ task which regularly checks whether the hashes of your NESO and
 Nektar++ builds has changed. If they have, it will update the
 symlinks. They will also be checked whenever the environment is
 activated or deactivated.
-
-It has been found that the oneAPI and clang
-compilers struggle to build NumPy and Boost due to very large memory
-requirements. As such, the oneAPI build of NESO compiles these
-dependencies using another compiler  (the Intel Classic compilers by default). Feel free to
-experiment with changing these or seeing if there is a way to make the
-builds work with oneAPI.
 
 #### Developing
 As you develop the code, there are a few options for how you
@@ -325,7 +318,7 @@ One pipeline for creating simple Nektar++ meshes is through Gmsh and NekMesh.
   .geo -> .msh in Gmsh
   .msh -> .xml with NekMesh
 
-A .geo file can be created using the Gmsh UI (each command adds a new line to the .geo file.  For simple meshes it may be easier to produce the .geo file in a text editor.  .geo files can also be loaded into the UI to edit.
+A .geo file can be created using the Gmsh UI (each command adds a new line to the .geo file).  For simple meshes it may be easier to produce the .geo file in a text editor.  .geo files can also be loaded into the UI to edit.
 <details>
   <summary>Expand</summary>
   mesh.geo

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,8 +5,8 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl ^py-numpy%intel
-      ^boost%intel ^py-cython%oneapi ^dpcpp ^scotch@6
+    - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl
+      ^py-cython%oneapi ^dpcpp ^scotch@6
     - neso%gcc ^openblas ^hipsycl ^scotch@6
   view:
     gcc-hipsycl:
@@ -15,7 +15,7 @@ spack:
       link_type: symlink
     oneapi-dpcpp:
       root: views/oneapi-dpcpp
-      select: ["%oneapi", "%intel"]
+      select: ["%oneapi"]
       link_type: symlink
   concretizer:
     unify: when_possible


### PR DESCRIPTION
# Description
Recent developments to NESO and NESO-Particles require using a later oneapi compiler version e.g. 2024.  This no longer has the classic compilers in.  See issue #260.
Spack 0.19 does not have oneapi@2024 so README updated to suggest using later version.  See issue #261 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change)
- [ ] Requires documentation updates

# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.

- [ ] Test Foo in /test/path/to/file_for_test_Foo.cpp
 - Description of test Foo
- [ ] Test Bar in /test/path/to/file_for_test_Bar.cpp
 - Description of test Bar

**Test Configuration**:

* OS:
* SYCL implementation:
* MPI details:
* Hardware:

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new dependencies are automatically built for users via `cmake`
- [ ] I have used understandable variable names
- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [ ] I have run `black` against changes to `*.py`
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

