### PR TITLE
Allow vector of Syms in output

### DIFF
--- a/include/nektar_interface/solver_base/partsys_base.hpp
+++ b/include/nektar_interface/solver_base/partsys_base.hpp
@@ -137,15 +137,15 @@ protected:
    *  @param args Remaining arguments (variable length) should be sym instances
    *  indicating which ParticleDats are to be written.
    */
-  template <typename... T> void init_output(std::string fname, T... args) {
+  template <typename... T> void init_output(std::string fname, T &&...args) {
     if (this->h5part) {
       if (this->sycl_target->comm_pair.rank_parent == 0) {
         nprint("Ignoring (duplicate?) call to init_output().");
       }
     } else {
       // Create H5Part instance
-      this->h5part =
-          std::make_shared<H5Part>(fname, this->particle_group, args...);
+      this->h5part = std::make_shared<H5Part>(fname, this->particle_group,
+                                              std::forward<T>(args)...);
     }
   }
 


### PR DESCRIPTION
# Description

Allows users to pass through vector of Syms for particle output.  Linked to https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles/pull/85

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

~- [ ] Bug fix (non-breaking change)~
- [x] New feature (non-breaking change which adds functionality)
~- [ ] API change (breaks downstream workflows and requires major semver bump)~
~- [ ] Requires documentation updates~

# Testing

Please describe the tests that you ran to verify your changes and provide instructions for reproducibility. Please also list any relevant details for your test configuration.

Tested with NESO-Tokamak

**Test Configuration**:

* OS:
* SYCL implementation:
* MPI details:
* Hardware:

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any new dependencies are automatically built for users via `cmake`
- [ ] I have used understandable variable names
- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes
- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`
- [ ] I have run `black` against changes to `*.py`
- [ ] I have made corresponding changes to the documentation
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
