### PR TITLE
Fix docs deployment

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,6 +1,5 @@
 name: Build Docs
 
-
 on:
   # Runs on pushes targeting the default branch
   push:
@@ -23,11 +22,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build job
   build:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Check out repository code
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v2
@@ -51,30 +55,9 @@ jobs:
           cp -r ./build/* /tmp/gh-pages/.
           touch /tmp/gh-pages/.nojekyll
           ls /tmp/gh-pages
-      - uses: actions/upload-artifact@master
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
-          name: gh-page
           path: /tmp/gh-pages
-          if-no-files-found: error
-
-  # Deployment job
-  deploy:
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/download-artifact@master
-      with:
-        name: gh-page
-        path: /tmp/gh-pages
-    - uses: actions/configure-pages@v1
-    - uses: actions/upload-pages-artifact@v1
-      with:
-        path: /tmp/gh-pages
-    - id: deployment
-      uses: actions/deploy-pages@main
+      - id: deployment
+        uses: actions/deploy-pages@main

--- a/docs/sphinx/source/concept/concept.rst
+++ b/docs/sphinx/source/concept/concept.rst
@@ -11,8 +11,8 @@ with the performance portable particle framework
 `NESO-Particles <https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles>`_ to solve
 plasma physics problems for tokamak exhausts at the exascale. Other satellite repositories
 include:
- - `NESO-Spack <https://github.com/ExCALIBUR-NEPTUNE/NESO-Spack>`_ for installation.
- - `NESO-Reactions <https://github.com/ExCALIBUR-NEPTUNE/NESO-Reactions>`_ for neutral, atomic and molecular dependencies.
- - `NESO-UQ <https://github.com/ExCALIBUR-NEPTUNE/NESO-UQ>`_ for uncertainty quantification dependencies.
+- `NESO-Spack <https://github.com/ExCALIBUR-NEPTUNE/NESO-Spack>`_ for installation.
+- `NESO-Reactions <https://github.com/ExCALIBUR-NEPTUNE/NESO-Reactions>`_ for neutral, atomic and molecular dependencies.
+- `NESO-UQ <https://github.com/ExCALIBUR-NEPTUNE/NESO-UQ>`_ for uncertainty quantification dependencies.
 
 This is a work in progress, but please do engage with us via issues etc.

--- a/docs/sphinx/source/guide-user/api_reference.rst
+++ b/docs/sphinx/source/guide-user/api_reference.rst
@@ -3,10 +3,3 @@ Doxygen API Reference
 *********************
 
 See `Original Doxygen output <../doxygen/html>`_ if preferred.
-
-
-********************
-Sphinx API Reference
-********************
-
-.. doxygenindex::

--- a/include/nektar_interface/utilities.hpp
+++ b/include/nektar_interface/utilities.hpp
@@ -126,7 +126,7 @@ inline void interpolate_onto_nektar_field_3d(T &func,
  *
  *  @param func Function matching a signature like: double func(double x,
  *  double y);
- *  @parma field Output Nektar++ field.
+ *  @param field Output Nektar++ field.
  */
 template <typename T, typename U>
 inline void interpolate_onto_nektar_field_2d(T &func,


### PR DESCRIPTION
# Description

Updates .github/workflows/build_docs.yaml to match NESO-Particles (but without the "dev" branch push trigger).
Also removed the Sphinx API reference (as in NP), which was causing the sphinx builds to fail.

## Type of change

- [x] Bug fix (non-breaking change)

# Testing

Added a temporary tag "tmpdel" to test deployment - result is [here](https://excalibur-neptune.github.io/NESO/tmpdel/sphinx/html/index.html).

# Checklist:

- [x] I have performed a self-review of my own code
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing unit tests pass locally with my changes~
~- [ ] Any new dependencies are automatically built for users via `cmake`~
~- [ ] I have used understandable variable names~
~- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes~
~- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`~
~- [ ] I have run `black` against changes to `*.py`~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] My changes generate no new warnings~
