### PR TITLE
Don't build nektar with CWIPI by default.

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,7 @@ spack:
   specs:
     - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl
       ^py-cython%oneapi ^dpcpp
-    - neso%gcc ^openblas ^adaptivecpp ^nektar+cwipi
+    - neso%gcc ^openblas ^adaptivecpp ^nektar
   view:
     adaptivecpp:
       root: views/adaptivecpp


### PR DESCRIPTION
# Description

Revert an accidental change to spack.yaml that causes nektar to be built with cwipi for gcc.

# Testing

Existing tests pass.

**Test Configuration**:

* OS: Ubuntu 22.04
* Compiler: GCC 11.3.0 / OneAPI 2024.1.0
* SYCL implementation: AdaptiveCpp 24.06.0 / DPC++ 2022.1.0
* MPI details: MPICH 4.0.2 / Intel MPI 2021.8 Build 20221129
* Hardware: CPU (Intel Raptor Lake)

# Checklist:

~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
~- [ ] Any new dependencies are automatically built for users via `cmake`~
~- [ ] I have used understandable variable names~
~- [ ] I have run `clang-format` against my `*.hpp` and `*.cpp` changes~
~- [ ] I have run `cmake-format` against my changes to `CMakeLists.txt`~
~- [ ] I have run `black` against changes to `*.py`~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have performed a self-review of my own code
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings