### PR TITLE
Feature/np standardised boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ set(HEADER_FILES
     ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_pyr.hpp
     ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_quad.hpp
     ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_quad_embed_3d.hpp
+    ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_relative_exit_tolerances.hpp
     ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_triangle_embed_3d.hpp
     ${INC_DIR}/nektar_interface/particle_cell_mapping/newton_tet.hpp
     ${INC_DIR}/nektar_interface/particle_cell_mapping/particle_cell_mapping.hpp

--- a/include/nektar_interface/composite_interaction/composite_collections.hpp
+++ b/include/nektar_interface/composite_interaction/composite_collections.hpp
@@ -114,6 +114,12 @@ public:
   std::map<int, std::map<int, std::shared_ptr<Geometry>>>
       map_composites_to_geoms;
 
+  // Map from geometry ids to geometry objects.
+  std::map<int, std::shared_ptr<Geometry>> map_geom_id_to_geoms;
+
+  // Map from geometry ids to composite ids.
+  std::map<int, int> map_geom_id_to_composite_id;
+
   /// The composite transport instance.
   std::shared_ptr<CompositeTransport> composite_transport;
 

--- a/include/nektar_interface/composite_interaction/composite_intersection.hpp
+++ b/include/nektar_interface/composite_interaction/composite_intersection.hpp
@@ -65,15 +65,11 @@ protected:
   void find_cells(std::shared_ptr<T> iteration_set, std::set<INT> &cells);
 
   template <typename T>
-  void find_intersections_2d(std::shared_ptr<T> iteration_set,
-                             ParticleDatSharedPtr<INT> dat_composite,
-                             ParticleDatSharedPtr<REAL> dat_positions,
-                             REAL *d_real, INT *d_int);
+  void find_intersections_2d(std::shared_ptr<T> iteration_set, REAL *d_real,
+                             INT *d_int);
   template <typename T>
-  void find_intersections_3d(std::shared_ptr<T> iteration_set,
-                             ParticleDatSharedPtr<INT> dat_composite,
-                             ParticleDatSharedPtr<REAL> dat_positions,
-                             REAL *d_real, INT *d_int);
+  void find_intersections_3d(std::shared_ptr<T> iteration_set, REAL *d_real,
+                             INT *d_int);
 
   static constexpr INT mask = std::numeric_limits<INT>::lowest();
 
@@ -92,11 +88,6 @@ public:
   /// position.
   const static inline Sym<REAL> previous_position_sym =
       Sym<REAL>("NESO_COMP_INT_PREV_POS");
-
-  const static inline std::string output_sym_position_name =
-      "NESO_COMP_INT_OUTPUT_POS";
-  const static inline std::string output_sym_composite_name =
-      "NESO_COMP_INT_OUTPUT_COMP";
 
   /// Map from boundary group id to composites in the group.
   std::map<int, std::vector<int>> boundary_groups;
@@ -132,10 +123,7 @@ public:
    *  @param output_sym_composite_name Optionally specifiy the property to
    *  store composite intersection information in. Otherwise use the default.
    */
-  template <typename T>
-  void pre_integration(std::shared_ptr<T> iteration_set,
-                       Sym<INT> output_sym_composite = Sym<INT>(
-                           CompositeIntersection::output_sym_composite_name));
+  template <typename T> void pre_integration(std::shared_ptr<T> iteration_set);
 
   /**
    *  Find intersections between particle trajectories and composites.
@@ -151,11 +139,7 @@ public:
    */
   template <typename T>
   std::map<int, ParticleSubGroupSharedPtr>
-  get_intersections(std::shared_ptr<T> iteration_set,
-                    Sym<INT> output_sym_composite = Sym<INT>(
-                        CompositeIntersection::output_sym_composite_name),
-                    Sym<REAL> output_sym_position = Sym<REAL>(
-                        CompositeIntersection::output_sym_position_name));
+  get_intersections(std::shared_ptr<T> iteration_set);
 };
 
 extern template void
@@ -163,53 +147,33 @@ CompositeIntersection::find_cells(std::shared_ptr<ParticleGroup> iteration_set,
                                   std::set<INT> &cells);
 
 extern template void CompositeIntersection::find_intersections_2d(
-    std::shared_ptr<ParticleGroup> iteration_set,
-    ParticleDatSharedPtr<INT> dat_composite,
-    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+    std::shared_ptr<ParticleGroup> iteration_set, REAL *d_real, INT *d_int);
 
 extern template void CompositeIntersection::find_intersections_3d(
-    std::shared_ptr<ParticleGroup> iteration_set,
-    ParticleDatSharedPtr<INT> dat_composite,
-    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+    std::shared_ptr<ParticleGroup> iteration_set, REAL *d_real, INT *d_int);
 
 extern template void CompositeIntersection::pre_integration(
-    std::shared_ptr<ParticleGroup> iteration_set,
-    Sym<INT> output_sym_composite =
-        Sym<INT>(CompositeIntersection::output_sym_composite_name));
+    std::shared_ptr<ParticleGroup> iteration_set);
 
 extern template std::map<int, ParticleSubGroupSharedPtr>
 CompositeIntersection::get_intersections(
-    std::shared_ptr<ParticleGroup> iteration_set,
-    Sym<INT> output_sym_composite =
-        Sym<INT>(CompositeIntersection::output_sym_composite_name),
-    Sym<REAL> output_sym_position =
-        Sym<REAL>(CompositeIntersection::output_sym_position_name));
+    std::shared_ptr<ParticleGroup> iteration_set);
 
 extern template void CompositeIntersection::find_cells(
     std::shared_ptr<ParticleSubGroup> iteration_set, std::set<INT> &cells);
 
 extern template void CompositeIntersection::find_intersections_2d(
-    std::shared_ptr<ParticleSubGroup> iteration_set,
-    ParticleDatSharedPtr<INT> dat_composite,
-    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+    std::shared_ptr<ParticleSubGroup> iteration_set, REAL *d_real, INT *d_int);
 
 extern template void CompositeIntersection::find_intersections_3d(
-    std::shared_ptr<ParticleSubGroup> iteration_set,
-    ParticleDatSharedPtr<INT> dat_composite,
-    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+    std::shared_ptr<ParticleSubGroup> iteration_set, REAL *d_real, INT *d_int);
 
 extern template void CompositeIntersection::pre_integration(
-    std::shared_ptr<ParticleSubGroup> iteration_set,
-    Sym<INT> output_sym_composite =
-        Sym<INT>(CompositeIntersection::output_sym_composite_name));
+    std::shared_ptr<ParticleSubGroup> iteration_set);
 
 extern template std::map<int, ParticleSubGroupSharedPtr>
 CompositeIntersection::get_intersections(
-    std::shared_ptr<ParticleSubGroup> iteration_set,
-    Sym<INT> output_sym_composite =
-        Sym<INT>(CompositeIntersection::output_sym_composite_name),
-    Sym<REAL> output_sym_position =
-        Sym<REAL>(CompositeIntersection::output_sym_position_name));
+    std::shared_ptr<ParticleSubGroup> iteration_set);
 
 } // namespace NESO::CompositeInteraction
 

--- a/include/nektar_interface/composite_interaction/composite_intersection.hpp
+++ b/include/nektar_interface/composite_interaction/composite_intersection.hpp
@@ -67,11 +67,13 @@ protected:
   template <typename T>
   void find_intersections_2d(std::shared_ptr<T> iteration_set,
                              ParticleDatSharedPtr<INT> dat_composite,
-                             ParticleDatSharedPtr<REAL> dat_positions);
+                             ParticleDatSharedPtr<REAL> dat_positions,
+                             REAL *d_real, INT *d_int);
   template <typename T>
   void find_intersections_3d(std::shared_ptr<T> iteration_set,
                              ParticleDatSharedPtr<INT> dat_composite,
-                             ParticleDatSharedPtr<REAL> dat_positions);
+                             ParticleDatSharedPtr<REAL> dat_positions,
+                             REAL *d_real, INT *d_int);
 
   static constexpr INT mask = std::numeric_limits<INT>::lowest();
 
@@ -136,24 +138,6 @@ public:
                            CompositeIntersection::output_sym_composite_name));
 
   /**
-   *  Find intersections between particle trajectories and composites. The
-   *  information of the intersections is stored only on the particles.
-   *
-   * @param iteration_set ParticleGroup or ParticleSubGroup which defines the
-   * set of particles.
-   * @param output_sym_composite Optionally place the information of which
-   * composite is hit into a different particle dat.
-   * @param output_sym_position Optionally place the information of where the
-   * intersection occurred in a different particle dat.
-   */
-  template <typename T>
-  void execute(std::shared_ptr<T> iteration_set,
-               Sym<INT> output_sym_composite =
-                   Sym<INT>(CompositeIntersection::output_sym_composite_name),
-               Sym<REAL> output_sym_position =
-                   Sym<REAL>(CompositeIntersection::output_sym_position_name));
-
-  /**
    *  Find intersections between particle trajectories and composites.
    *
    * @param iteration_set ParticleGroup or ParticleSubGroup which defines the
@@ -173,6 +157,59 @@ public:
                     Sym<REAL> output_sym_position = Sym<REAL>(
                         CompositeIntersection::output_sym_position_name));
 };
+
+extern template void
+CompositeIntersection::find_cells(std::shared_ptr<ParticleGroup> iteration_set,
+                                  std::set<INT> &cells);
+
+extern template void CompositeIntersection::find_intersections_2d(
+    std::shared_ptr<ParticleGroup> iteration_set,
+    ParticleDatSharedPtr<INT> dat_composite,
+    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+
+extern template void CompositeIntersection::find_intersections_3d(
+    std::shared_ptr<ParticleGroup> iteration_set,
+    ParticleDatSharedPtr<INT> dat_composite,
+    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+
+extern template void CompositeIntersection::pre_integration(
+    std::shared_ptr<ParticleGroup> iteration_set,
+    Sym<INT> output_sym_composite =
+        Sym<INT>(CompositeIntersection::output_sym_composite_name));
+
+extern template std::map<int, ParticleSubGroupSharedPtr>
+CompositeIntersection::get_intersections(
+    std::shared_ptr<ParticleGroup> iteration_set,
+    Sym<INT> output_sym_composite =
+        Sym<INT>(CompositeIntersection::output_sym_composite_name),
+    Sym<REAL> output_sym_position =
+        Sym<REAL>(CompositeIntersection::output_sym_position_name));
+
+extern template void CompositeIntersection::find_cells(
+    std::shared_ptr<ParticleSubGroup> iteration_set, std::set<INT> &cells);
+
+extern template void CompositeIntersection::find_intersections_2d(
+    std::shared_ptr<ParticleSubGroup> iteration_set,
+    ParticleDatSharedPtr<INT> dat_composite,
+    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+
+extern template void CompositeIntersection::find_intersections_3d(
+    std::shared_ptr<ParticleSubGroup> iteration_set,
+    ParticleDatSharedPtr<INT> dat_composite,
+    ParticleDatSharedPtr<REAL> dat_positions, REAL *d_real, INT *d_int);
+
+extern template void CompositeIntersection::pre_integration(
+    std::shared_ptr<ParticleSubGroup> iteration_set,
+    Sym<INT> output_sym_composite =
+        Sym<INT>(CompositeIntersection::output_sym_composite_name));
+
+extern template std::map<int, ParticleSubGroupSharedPtr>
+CompositeIntersection::get_intersections(
+    std::shared_ptr<ParticleSubGroup> iteration_set,
+    Sym<INT> output_sym_composite =
+        Sym<INT>(CompositeIntersection::output_sym_composite_name),
+    Sym<REAL> output_sym_position =
+        Sym<REAL>(CompositeIntersection::output_sym_position_name));
 
 } // namespace NESO::CompositeInteraction
 

--- a/include/nektar_interface/composite_interaction/composite_intersection.hpp
+++ b/include/nektar_interface/composite_interaction/composite_intersection.hpp
@@ -52,15 +52,6 @@ protected:
                   std::is_same_v<T, ParticleSubGroup>);
   }
 
-  inline ParticleGroupSharedPtr
-  get_particle_group(ParticleGroupSharedPtr iteration_set) {
-    return iteration_set;
-  }
-  inline ParticleGroupSharedPtr
-  get_particle_group(ParticleSubGroupSharedPtr iteration_set) {
-    return iteration_set->get_particle_group();
-  }
-
   template <typename T>
   void find_cells(std::shared_ptr<T> iteration_set, std::set<INT> &cells);
 
@@ -70,8 +61,6 @@ protected:
   template <typename T>
   void find_intersections_3d(std::shared_ptr<T> iteration_set, REAL *d_real,
                              INT *d_int);
-
-  static constexpr INT mask = std::numeric_limits<INT>::lowest();
 
 public:
   /// The CompositeCollections used to detect intersections.

--- a/include/nektar_interface/particle_boundary_conditions.hpp
+++ b/include/nektar_interface/particle_boundary_conditions.hpp
@@ -90,14 +90,13 @@ protected:
   std::shared_ptr<CompositeInteraction::CompositeIntersection>
       composite_intersection;
   std::vector<int> composite_indices;
-  std::unique_ptr<ErrorPropagate> ep;
   Sym<REAL> velocity_sym;
   Sym<REAL> time_step_prop_sym;
   REAL reset_distance;
   int ndim;
 
-  void execute_2d(ParticleSubGroupSharedPtr particle_sub_group);
-  void execute_3d(ParticleSubGroupSharedPtr particle_sub_group);
+  // The standard NESO-Particles reflection implementation
+  std::shared_ptr<BoundaryReflection> boundary_reflection;
 
 public:
   /**

--- a/include/nektar_interface/particle_cell_mapping/x_map_newton.hpp
+++ b/include/nektar_interface/particle_cell_mapping/x_map_newton.hpp
@@ -408,18 +408,8 @@ public:
               //// SYCL functions as we have used all the local memory already
               //// and the SYCL reduction functions also use local memory.
               for (int dimx = 0; dimx < 3; dimx++) {
-                {
-                  sycl::atomic_ref<REAL, sycl::memory_order::relaxed,
-                                   sycl::memory_scope::device>
-                      ar(k_fdata[dimx + 3]);
-                  ar.fetch_max(f[dimx]);
-                }
-                {
-                  sycl::atomic_ref<REAL, sycl::memory_order::relaxed,
-                                   sycl::memory_scope::device>
-                      ar(k_fdata[dimx]);
-                  ar.fetch_min(f[dimx]);
-                }
+                { atomic_fetch_max(&k_fdata[dimx + 3], f[dimx]); }
+                { atomic_fetch_min(&k_fdata[dimx], f[dimx]); }
               }
             });
       }));

--- a/include/nektar_interface/particle_cell_mapping/x_map_newton.hpp
+++ b/include/nektar_interface/particle_cell_mapping/x_map_newton.hpp
@@ -408,8 +408,8 @@ public:
               //// SYCL functions as we have used all the local memory already
               //// and the SYCL reduction functions also use local memory.
               for (int dimx = 0; dimx < 3; dimx++) {
-                { atomic_fetch_max(&k_fdata[dimx + 3], f[dimx]); }
-                { atomic_fetch_min(&k_fdata[dimx], f[dimx]); }
+                atomic_fetch_max(&k_fdata[dimx + 3], f[dimx]);
+                atomic_fetch_min(&k_fdata[dimx], f[dimx]);
               }
             });
       }));

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - neso%oneapi ^nektar%oneapi ^intel-oneapi-mpi ^intel-oneapi-mkl
+    - neso%oneapi ^nektar%oneapi^intel-oneapi-mkl%oneapi ^intel-oneapi-mpi%oneapi ^intel-oneapi-mkl%oneapi
       ^py-cython%oneapi ^dpcpp
     - neso%gcc ^openblas  ^nektar ^adaptivecpp compilationflow=omplibraryonly
     #- neso%gcc ^openblas  ^nektar ^adaptivecpp compilationflow=ompaccelerated

--- a/src/nektar_interface/composite_interaction/composite_collections.cpp
+++ b/src/nektar_interface/composite_interaction/composite_collections.cpp
@@ -91,6 +91,9 @@ void CompositeCollections::collect_cell(const INT cell) {
       geom_ids[gx] = remote_geom->id;
       this->map_composites_to_geoms[composite_id][remote_geom->id] =
           std::dynamic_pointer_cast<Geometry>(geom);
+      this->map_geom_id_to_geoms[remote_geom->id] =
+          std::dynamic_pointer_cast<Geometry>(geom);
+      this->map_geom_id_to_composite_id[remote_geom->id] = composite_id;
       lambda_push_normal(remote_geom->id,
                          std::dynamic_pointer_cast<Geometry2D>(geom));
       h_group_ids_quads.push_back(
@@ -110,6 +113,9 @@ void CompositeCollections::collect_cell(const INT cell) {
       geom_ids[num_quads + gx] = remote_geom->id;
       this->map_composites_to_geoms[composite_id][remote_geom->id] =
           std::dynamic_pointer_cast<Geometry>(geom);
+      this->map_geom_id_to_geoms[remote_geom->id] =
+          std::dynamic_pointer_cast<Geometry>(geom);
+      this->map_geom_id_to_composite_id[remote_geom->id] = composite_id;
       lambda_push_normal(remote_geom->id,
                          std::dynamic_pointer_cast<Geometry2D>(geom));
       h_group_ids_tris.push_back(this->map_composite_to_group.at(composite_id));
@@ -184,6 +190,10 @@ void CompositeCollections::collect_cell(const INT cell) {
       lli_segments.emplace_back(rs->geom);
       this->map_composites_to_geoms[rs->rank][rs->id] =
           std::dynamic_pointer_cast<Geometry>(rs->geom);
+      this->map_geom_id_to_geoms[rs->id] =
+          std::dynamic_pointer_cast<Geometry>(rs->geom);
+      this->map_geom_id_to_composite_id[rs->id] = rs->rank;
+
       lambda_push_normal(rs->id,
                          std::dynamic_pointer_cast<Geometry1D>(rs->geom));
       h_group_ids_segments.push_back(this->map_composite_to_group.at(rs->rank));

--- a/src/nektar_interface/composite_interaction/composite_intersection.cpp
+++ b/src/nektar_interface/composite_interaction/composite_intersection.cpp
@@ -34,8 +34,7 @@ void CompositeIntersection::find_cells(std::shared_ptr<T> iteration_set,
   NESOASSERT(this->ndim < 4,
              "Method assumes no more than 3 spatial dimensions.");
 
-  auto particle_group = this->get_particle_group(iteration_set);
-  const auto position_dat = particle_group->position_dat;
+  const auto position_dat = get_particle_group(iteration_set)->position_dat;
   const int k_ndim = this->ndim;
 
   const auto mesh_hierarchy_device_mapper =
@@ -238,10 +237,9 @@ template <typename T>
 void CompositeIntersection::find_intersections_2d(
     std::shared_ptr<T> iteration_set, REAL *d_real, INT *d_int) {
   this->check_iteration_set(iteration_set);
-  auto particle_group = this->get_particle_group(iteration_set);
   NESOASSERT(this->ndim == 2, "Method assumes 2 spatial dimensions.");
 
-  const auto position_dat = particle_group->position_dat;
+  const auto position_dat = get_particle_group(iteration_set)->position_dat;
   const int k_ndim = this->ndim;
   const auto mesh_hierarchy_device_mapper =
       this->mesh_hierarchy_mapper->get_device_mapper();
@@ -380,10 +378,9 @@ template <typename T>
 void CompositeIntersection::find_intersections_3d(
     std::shared_ptr<T> iteration_set, REAL *d_real, INT *d_int) {
   this->check_iteration_set(iteration_set);
-  auto particle_group = this->get_particle_group(iteration_set);
   NESOASSERT(this->ndim == 3, "Method assumes 3 spatial dimensions.");
 
-  const auto position_dat = particle_group->position_dat;
+  const auto position_dat = get_particle_group(iteration_set)->position_dat;
   const int k_ndim = this->ndim;
   const auto mesh_hierarchy_device_mapper =
       this->mesh_hierarchy_mapper->get_device_mapper();
@@ -398,7 +395,6 @@ void CompositeIntersection::find_intersections_3d(
     const double k_newton_tol = this->newton_tol;
     const double k_contained_tol = this->contained_tol;
     const int k_max_iterations = this->newton_max_iteration;
-    const auto k_MASK = this->mask;
     const int grid_size = std::max(
         this->num_modes_factor * this->composite_collections->max_num_modes - 1,
         1);
@@ -790,12 +786,6 @@ CompositeIntersection::CompositeIntersection(
       boundary_groups(boundary_groups),
       num_cells(particle_mesh_interface->get_cell_count()) {
 
-  for (auto pair : boundary_groups) {
-    NESOASSERT(pair.first != this->mask,
-               "Cannot have a boundary group with label " +
-                   std::to_string(this->mask) + ".");
-  }
-
   this->composite_collections = std::make_shared<CompositeCollections>(
       sycl_target, particle_mesh_interface, boundary_groups);
   this->mesh_hierarchy_mapper = std::make_unique<MeshHierarchyMapper>(
@@ -826,7 +816,7 @@ CompositeIntersection::CompositeIntersection(
 template <typename T>
 void CompositeIntersection::pre_integration(std::shared_ptr<T> iteration_set) {
   this->check_iteration_set(iteration_set);
-  auto particle_group = this->get_particle_group(iteration_set);
+  auto particle_group = get_particle_group(iteration_set);
   const auto position_dat = particle_group->position_dat;
   const int ndim = position_dat->ncomp;
   NESOASSERT(ndim == this->ndim,
@@ -856,7 +846,7 @@ std::map<int, ParticleSubGroupSharedPtr>
 CompositeIntersection::get_intersections(std::shared_ptr<T> iteration_set) {
 
   this->check_iteration_set(iteration_set);
-  auto particle_group = this->get_particle_group(iteration_set);
+  auto particle_group = get_particle_group(iteration_set);
 
   NESOASSERT(
       particle_group->contains_dat(previous_position_sym),

--- a/src/nektar_interface/particle_boundary_conditions.cpp
+++ b/src/nektar_interface/particle_boundary_conditions.cpp
@@ -71,7 +71,7 @@ NektarCartesianPeriodic::NektarCartesianPeriodic(
         }
       },
       Access::write(this->position_dat));
-};
+}
 
 void NektarCartesianPeriodic::execute() { this->loop->execute(); }
 
@@ -89,10 +89,12 @@ NektarCompositeTruncatedReflection::NektarCompositeTruncatedReflection(
   this->composite_intersection =
       std::make_shared<CompositeInteraction::CompositeIntersection>(
           this->sycl_target, mesh, boundary_groups);
-  this->ep = std::make_unique<ErrorPropagate>(this->sycl_target);
 
   this->reset_distance = config->get<REAL>(
       "NektarCompositeTruncatedReflection/reset_distance", 1.0e-7);
+
+  this->boundary_reflection =
+      std::make_shared<BoundaryReflection>(this->ndim, this->reset_distance);
 }
 
 void NektarCompositeTruncatedReflection::pre_advection(
@@ -100,228 +102,20 @@ void NektarCompositeTruncatedReflection::pre_advection(
   this->composite_intersection->pre_integration(particle_sub_group);
 }
 
-void NektarCompositeTruncatedReflection::execute_2d(
-    ParticleSubGroupSharedPtr particle_sub_group) {
-  auto particle_groups =
-      this->composite_intersection->get_intersections(particle_sub_group);
-
-  auto k_ep = this->ep->device_ptr();
-  const REAL k_reset_distance = this->reset_distance;
-
-  const auto k_normal_device_mapper =
-      this->composite_intersection->composite_collections
-          ->get_device_normal_mapper();
-
-  if (particle_groups.count(1)) {
-    auto pg = particle_groups.at(1);
-    particle_loop(
-        "NektarCompositeTruncatedReflection2D", pg,
-        [=](auto V, auto P, auto PP, auto IC, auto IP, auto TSP) {
-          REAL *normal;
-          const bool normal_exists =
-              k_normal_device_mapper.get(IC.at(2), &normal);
-          NESO_KERNEL_ASSERT(normal_exists, k_ep);
-          if (normal_exists) {
-            // Normal vector
-            const REAL n0 = normal[0];
-            const REAL n1 = normal[1];
-            const REAL p0 = P.at(0);
-            const REAL p1 = P.at(1);
-            const REAL v0 = V.at(0);
-            const REAL v1 = V.at(1);
-            // We don't know if the normal is inwards pointing or outwards
-            // pointing.
-            const REAL in_dot_product = KERNEL_DOT_PRODUCT_2D(n0, n1, v0, v1);
-
-            // compute new velocity from reflection
-            V.at(0) = v0 - 2.0 * in_dot_product * n0;
-            V.at(1) = v1 - 2.0 * in_dot_product * n1;
-
-            // Try and compute a sane new position
-            // vector from intersection point back towards previous position
-            const REAL oo0 = PP.at(0) - IP.at(0);
-            const REAL oo1 = PP.at(1) - IP.at(1);
-            REAL o0 = oo0;
-            REAL o1 = oo1;
-
-            const REAL o_norm2 = KERNEL_DOT_PRODUCT_2D(oo0, oo1, oo0, oo1);
-            const REAL o_norm = Kernel::sqrt(o_norm2);
-            const bool small_move = o_norm < (k_reset_distance * 0.1);
-
-            const REAL o_inorm =
-                small_move ? k_reset_distance : k_reset_distance / o_norm;
-            o0 *= o_inorm;
-            o1 *= o_inorm;
-            // If the move is tiny place the particle back on the previous
-            // position
-            REAL np0 = small_move ? PP.at(0) : IP.at(0) + o0;
-            REAL np1 = small_move ? PP.at(1) : IP.at(1) + o1;
-            // Detect if we moved the particle back past the previous position
-            // Both PP - np and PP - IP should have the same sign
-            const bool moved_past_pp =
-                ((PP.at(0) - np0) * o0 < 0.0) || ((PP.at(1) - np1) * o1 < 0.0);
-
-            np0 = moved_past_pp ? PP.at(0) : np0;
-            np1 = moved_past_pp ? PP.at(1) : np1;
-            P.at(0) = np0;
-            P.at(1) = np1;
-
-            // Timestepping adjustment
-            const REAL dist_trunc_step = o_norm2;
-
-            const REAL f0 = p0 - PP.at(0);
-            const REAL f1 = p1 - PP.at(1);
-            const REAL dist_full_step = KERNEL_DOT_PRODUCT_2D(f0, f1, f0, f1);
-
-            REAL tmp_prop_achieved = dist_full_step > 1.0e-16
-                                         ? dist_trunc_step / dist_full_step
-                                         : 1.0;
-            tmp_prop_achieved =
-                tmp_prop_achieved < 0.0 ? 0.0 : tmp_prop_achieved;
-            tmp_prop_achieved =
-                tmp_prop_achieved > 1.0 ? 1.0 : tmp_prop_achieved;
-
-            // proportion along the full step that we truncated at
-            const REAL proportion_achieved = Kernel::sqrt(tmp_prop_achieved);
-            const REAL last_dt = TSP.at(1);
-            const REAL correct_last_dt = TSP.at(1) * proportion_achieved;
-            TSP.at(0) = TSP.at(0) - last_dt + correct_last_dt;
-            TSP.at(1) = correct_last_dt;
-          }
-        },
-        Access::write(this->velocity_sym),
-        Access::write(pg->get_particle_group()->position_dat),
-        Access::read(Sym<REAL>("NESO_COMP_INT_PREV_POS")),
-        Access::read(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP")),
-        Access::read(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS")),
-        Access::write(this->time_step_prop_sym))
-        ->execute();
-  }
-
-  this->ep->check_and_throw(
-      "Failed to reflect particle off geometry composite.");
-}
-
-void NektarCompositeTruncatedReflection::execute_3d(
-    ParticleSubGroupSharedPtr particle_sub_group) {
-  auto particle_groups =
-      this->composite_intersection->get_intersections(particle_sub_group);
-
-  auto k_ep = this->ep->device_ptr();
-  const REAL k_reset_distance = this->reset_distance;
-
-  const auto k_normal_device_mapper =
-      this->composite_intersection->composite_collections
-          ->get_device_normal_mapper();
-
-  if (particle_groups.count(1)) {
-    auto pg = particle_groups.at(1);
-    particle_loop(
-        "NektarCompositeTruncatedReflection3D", pg,
-        [=](auto V, auto P, auto PP, auto IC, auto IP, auto TSP) {
-          const INT geom_id = static_cast<INT>(IC.at(2));
-          REAL *normal;
-          const bool exists = k_normal_device_mapper.get(geom_id, &normal);
-          NESO_KERNEL_ASSERT(exists, k_ep);
-
-          // Normal vector
-          const REAL n0 = normal[0];
-          const REAL n1 = normal[1];
-          const REAL n2 = normal[2];
-          const REAL p0 = P.at(0);
-          const REAL p1 = P.at(1);
-          const REAL p2 = P.at(2);
-          const REAL v0 = V.at(0);
-          const REAL v1 = V.at(1);
-          const REAL v2 = V.at(2);
-          const REAL in_dot_product =
-              MAPPING_DOT_PRODUCT_3D(n0, n1, n2, v0, v1, v2);
-
-          // compute new velocity from reflection
-          V.at(0) = v0 - 2.0 * in_dot_product * n0;
-          V.at(1) = v1 - 2.0 * in_dot_product * n1;
-          V.at(2) = v2 - 2.0 * in_dot_product * n2;
-
-          // Compute a sane new position
-
-          // vector from intersection point back towards previous position
-          const REAL oo0 = PP.at(0) - IP.at(0);
-          const REAL oo1 = PP.at(1) - IP.at(1);
-          const REAL oo2 = PP.at(2) - IP.at(2);
-          REAL o0 = oo0;
-          REAL o1 = oo1;
-          REAL o2 = oo2;
-
-          const REAL o_norm2 =
-              MAPPING_DOT_PRODUCT_3D(oo0, oo1, oo2, oo0, oo1, oo2);
-          const REAL o_norm = sqrt(o_norm2);
-          const bool small_move = o_norm < (k_reset_distance * 0.1);
-          const REAL o_inorm =
-              small_move ? k_reset_distance : k_reset_distance / o_norm;
-          o0 *= o_inorm;
-          o1 *= o_inorm;
-          o2 *= o_inorm;
-          // If the move is tiny place the particle back on the previous
-          // position
-          REAL np0 = small_move ? PP.at(0) : IP.at(0) + o0;
-          REAL np1 = small_move ? PP.at(1) : IP.at(1) + o1;
-          REAL np2 = small_move ? PP.at(2) : IP.at(2) + o2;
-          // Detect if we moved the particle back past the previous position
-          // Both PP - np and PP - IP should have the same sign
-          const bool moved_past_pp = ((PP.at(0) - np0) * o0 < 0.0) ||
-                                     ((PP.at(1) - np1) * o1 < 0.0) ||
-                                     ((PP.at(2) - np2) * o2 < 0.0);
-
-          np0 = moved_past_pp ? PP.at(0) : np0;
-          np1 = moved_past_pp ? PP.at(1) : np1;
-          np2 = moved_past_pp ? PP.at(2) : np2;
-
-          P.at(0) = np0;
-          P.at(1) = np1;
-          P.at(2) = np2;
-
-          // Timestepping adjustment
-          const REAL dist_trunc_step = o_norm2;
-
-          const REAL f0 = p0 - PP.at(0);
-          const REAL f1 = p1 - PP.at(1);
-          const REAL f2 = p2 - PP.at(2);
-          const REAL dist_full_step =
-              MAPPING_DOT_PRODUCT_3D(f0, f1, f2, f0, f1, f2);
-
-          REAL tmp_prop_achieved =
-              dist_full_step > 1.0e-16 ? dist_trunc_step / dist_full_step : 1.0;
-          tmp_prop_achieved = tmp_prop_achieved < 0.0 ? 0.0 : tmp_prop_achieved;
-          tmp_prop_achieved = tmp_prop_achieved > 1.0 ? 1.0 : tmp_prop_achieved;
-
-          // proportion along the full step that we truncated at
-          const REAL proportion_achieved = sqrt(tmp_prop_achieved);
-          const REAL last_dt = TSP.at(1);
-          const REAL correct_last_dt = TSP.at(1) * proportion_achieved;
-          TSP.at(0) = TSP.at(0) - last_dt + correct_last_dt;
-          TSP.at(1) = correct_last_dt;
-        },
-        Access::write(this->velocity_sym),
-        Access::write(pg->get_particle_group()->position_dat),
-        Access::read(Sym<REAL>("NESO_COMP_INT_PREV_POS")),
-        Access::read(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP")),
-        Access::read(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS")),
-        Access::write(this->time_step_prop_sym))
-        ->execute();
-  }
-
-  this->ep->check_and_throw(
-      "Failed to reflect particle off geometry composite.");
-}
-
 void NektarCompositeTruncatedReflection::execute(
     ParticleSubGroupSharedPtr particle_sub_group) {
   NESOASSERT(this->ndim == 3 || this->ndim == 2,
              "Unexpected number of dimensions.");
-  if (this->ndim == 3) {
-    this->execute_3d(particle_sub_group);
-  } else {
-    this->execute_2d(particle_sub_group);
+
+  auto groups =
+      this->composite_intersection->get_intersections(particle_sub_group);
+
+  for (auto &groupx : groups) {
+    this->boundary_reflection->execute(
+        groupx.second,
+        get_particle_group(particle_sub_group)->position_dat->sym,
+        this->velocity_sym, this->time_step_prop_sym,
+        this->composite_intersection->previous_position_sym);
   }
 }
 

--- a/test/unit/nektar_interface/test_composite_interaction.cpp
+++ b/test/unit/nektar_interface/test_composite_interaction.cpp
@@ -798,6 +798,12 @@ TEST_P(CompositeInteractionAllD, Intersection) {
 
   // Test pre integration actually copied the current positions
   composite_intersection->pre_integration(A);
+  if (!A->contains_dat(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS"))) {
+    A->add_particle_dat(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS"), ndim);
+  }
+  if (!A->contains_dat(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP"))) {
+    A->add_particle_dat(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP"), 2);
+  }
 
   for (int cellx = 0; cellx < cell_count; cellx++) {
     auto P = A->position_dat->cell_dat.get_cell(cellx);
@@ -864,26 +870,30 @@ TEST_P(CompositeInteractionAllD, Intersection) {
       Access::write(Sym<REAL>("P")),
       Access::read(Sym<REAL>("NESO_COMP_INT_PREV_POS")));
 
-  auto lambda_test_normal = [&](auto correct_normal) {
+  auto lambda_test_normal = [&](auto correct_normal, auto &sub_groups) {
     auto device_normal_mapper = composite_intersection->composite_collections
                                     ->get_device_normal_mapper();
     auto error_propagate = std::make_shared<ErrorPropagate>(sycl_target);
-    auto k_ep = error_propagate->device_ptr();
-    particle_loop(
-        A,
-        [=](auto IN, auto IC) {
-          REAL *normal;
-          const INT geom_id = IC.at(2);
-          const bool has_normal = device_normal_mapper.get(geom_id, &normal);
-          NESO_KERNEL_ASSERT(has_normal, k_ep);
-          for (int dx = 0; dx < ndim; dx++) {
-            IN.at(dx) = normal[dx];
-          }
-        },
-        Access::write(Sym<REAL>("NORMAL")),
-        Access::read(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP")))
-        ->execute();
-    ASSERT_FALSE(error_propagate->get_flag());
+
+    for (auto &pairx : sub_groups) {
+      auto k_ep = error_propagate->device_ptr();
+
+      particle_loop(
+          pairx.second,
+          [=](auto IN, auto IC) {
+            REAL *normal;
+            const INT geom_id = IC.at_ephemeral(1);
+            const bool has_normal = device_normal_mapper.get(geom_id, &normal);
+            NESO_KERNEL_ASSERT(has_normal, k_ep);
+            for (int dx = 0; dx < ndim; dx++) {
+              IN.at(dx) = normal[dx];
+            }
+          },
+          Access::write(Sym<REAL>("NORMAL")),
+          Access::read(Sym<INT>("NESO_PARTICLES_BOUNDARY_METADATA")))
+          ->execute();
+      ASSERT_FALSE(error_propagate->get_flag());
+    }
 
     for (int cellx = 0; cellx < cell_count; cellx++) {
       auto IN = A->get_cell(Sym<REAL>("NORMAL"), cellx);
@@ -899,11 +909,35 @@ TEST_P(CompositeInteractionAllD, Intersection) {
 
   auto lambda_test = [&](const int expected_composite, auto correct_normal) {
     composite_intersection->pre_integration(A);
+
     ASSERT_TRUE(A->contains_dat(Sym<REAL>("NESO_COMP_INT_PREV_POS")));
     lambda_apply_offset();
     auto sub_groups = composite_intersection->get_intersections(A);
-    ASSERT_TRUE(A->contains_dat(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS")));
-    ASSERT_TRUE(A->contains_dat(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP")));
+
+    for (auto &pairx : sub_groups) {
+
+      ASSERT_TRUE(pairx.second->contains_ephemeral_dat(
+          Sym<REAL>("NESO_PARTICLES_BOUNDARY_INTERSECTION_POINT")));
+      ASSERT_TRUE(pairx.second->contains_ephemeral_dat(
+          Sym<REAL>("NESO_PARTICLES_BOUNDARY_NORMAL")));
+      ASSERT_TRUE(pairx.second->contains_ephemeral_dat(
+          Sym<INT>("NESO_PARTICLES_BOUNDARY_METADATA")));
+
+      particle_loop(
+          pairx.second,
+          [=](auto OUTPUT_POS, auto OUTPUT_COMP, auto EPH_POS, auto EPH_COMP) {
+            for (int dx = 0; dx < ndim; dx++) {
+              OUTPUT_POS.at(dx) = EPH_POS.at_ephemeral(dx);
+            }
+            OUTPUT_COMP.at(0) = EPH_COMP.at_ephemeral(0);
+            OUTPUT_COMP.at(1) = EPH_COMP.at_ephemeral(1);
+          },
+          Access::write(Sym<REAL>("NESO_COMP_INT_OUTPUT_POS")),
+          Access::write(Sym<INT>("NESO_COMP_INT_OUTPUT_COMP")),
+          Access::read(Sym<REAL>("NESO_PARTICLES_BOUNDARY_INTERSECTION_POINT")),
+          Access::read(Sym<INT>("NESO_PARTICLES_BOUNDARY_METADATA")))
+          ->execute();
+    }
 
     int local_count = 0;
     for (int cellx = 0; cellx < cell_count; cellx++) {
@@ -913,13 +947,13 @@ TEST_P(CompositeInteractionAllD, Intersection) {
       for (int rowx = 0; rowx < P->nrow; rowx++) {
 
         auto hit_composite = IC->at(rowx, 0);
-        auto composite_id = IC->at(rowx, 1);
-        auto geom_id = IC->at(rowx, 2);
+        auto geom_id = IC->at(rowx, 1);
+        auto composite_id = composite_intersection->composite_collections
+                                ->map_geom_id_to_composite_id.at(geom_id);
         ASSERT_EQ(hit_composite, expected_composite);
 
         auto geom = composite_intersection->composite_collections
-                        ->map_composites_to_geoms.at(composite_id)
-                        .at(geom_id);
+                        ->map_geom_id_to_geoms.at(geom_id);
 
         Array<OneD, NekDouble> point(3);
         Array<OneD, NekDouble> local_point(3);
@@ -963,7 +997,7 @@ TEST_P(CompositeInteractionAllD, Intersection) {
       }
     }
 
-    lambda_test_normal(correct_normal);
+    lambda_test_normal(correct_normal, sub_groups);
   };
 
   REAL correct_normal[3] = {0.0, 0.0, 0.0};

--- a/test/unit/nektar_interface/test_composite_interaction.cpp
+++ b/test/unit/nektar_interface/test_composite_interaction.cpp
@@ -53,14 +53,8 @@ TEST(CompositeInteraction, AtomicFetchMaxMin) {
   sycl_target->queue
       .submit([&](sycl::handler &cgh) {
         cgh.parallel_for<>(sycl::range<1>(1), [=](sycl::id<1> idx) {
-          sycl::atomic_ref<TEST_INT, sycl::memory_order::relaxed,
-                           sycl::memory_scope::device>
-              amax(k_buffer[0]);
-          amax.fetch_max((TEST_INT)8);
-          sycl::atomic_ref<TEST_INT, sycl::memory_order::relaxed,
-                           sycl::memory_scope::device>
-              amin(k_buffer[1]);
-          amin.fetch_min((TEST_INT)-8);
+          atomic_fetch_max(k_buffer, (TEST_INT)8);
+          atomic_fetch_min(&k_buffer[1], (TEST_INT)-8);
         });
       })
       .wait_and_throw();


### PR DESCRIPTION
* Re-implements the boundary intersection information to be in the format described here [1].
* Tests pass with acpp: cudallvm and ompaccelerated, and oneapi.
* Fixes some atomic calls preventing compilation with cudallvm workflow.
* Removes the reflection implementation and simply now calls the one in NP using the standard interface.

[1] https://github.com/ExCALIBUR-NEPTUNE/NESO-Particles/blob/dev/include/neso_particles/boundary/boundary_interaction_specification.hpp